### PR TITLE
Test: backport label gate workflow

### DIFF
--- a/.github/.backport-gate-test
+++ b/.github/.backport-gate-test
@@ -1,0 +1,1 @@
+Test PR for backport label gate (safe to delete).


### PR DESCRIPTION
## Summary

Intentionally opens a PR with **no backport labels** to verify that the new `Validate Backport Labels` check fails as expected.

This PR also confirms that the gate workflow posts/updates a sticky comment listing available `backport/release-vX.Y` labels (created earlier by the `Sync Backport Labels` workflow run).

## Test plan

- [ ] Gate check appears red on this PR
- [ ] Sticky comment appears listing available labels
- [ ] Adding `skip-releases-backport` flips the check to green
- [ ] Removing it flips back to red
- [ ] Adding a `backport/release-vX.Y` label flips to green
- [ ] After all scenarios pass, the gate name shows up in branch protection's required-checks dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)