### PR TITLE
Test v2: backport label gate (post-cleanup)

### DIFF
--- a/.github/.backport-gate-test-v2
+++ b/.github/.backport-gate-test-v2
@@ -1,0 +1,1 @@
+Test PR (v2) for backport label gate after label cleanup.


### PR DESCRIPTION
## Summary

Fresh test PR opened after the backport label cleanup (24 → 5 labels). Verifies that the gate workflow now lists only the 5 active `backport/release-vX.Y` labels in its sticky comment.

## Test plan

- [ ] Gate check appears red (no labels set)
- [ ] Sticky comment lists only 5 backport labels: `release-v3.27` → `release-v3.31`
- [ ] Adding `skip-releases-backport` flips the check to green
- [ ] Adding any single `backport/release-vX.Y` label flips to green
- [ ] Removing all backport-related labels flips back to red

🤖 Generated with [Claude Code](https://claude.com/claude-code)