### PR TITLE
daily-test D1: plain bugfix

### DIFF
--- a/.daily-tick-test/D1.txt
+++ b/.daily-tick-test/D1.txt
@@ -1,0 +1,1 @@
+Fixture D1: plain bugfix (no backport labels)


### PR DESCRIPTION
Fixture D1 for daily-tick test (no backport labels, no skip label). EE pick state should be Pending → appears in Missing Cherry-picks (calico-private master) section.