### PR TITLE
Test: fork-PR permissions for backport-label workflows

### DIFF
--- a/fork-pr-permissions-test.md
+++ b/fork-pr-permissions-test.md
@@ -1,0 +1,17 @@
+# Fork PR permissions test (2026-05-20)
+
+Smoke test for the backport-label workflows when triggered by a cross-fork
+PR. The head repo (`skoryk-oleksandr/calico`) and the base repo
+(`tigera/calico-oss-test`) are sibling forks in the `projectcalico/calico`
+fork network, so this PR runs with a read-only `GITHUB_TOKEN` exactly as an
+external contributor's PR would.
+
+Expected behavior:
+- `check_backport_labels.yml` runs and computes the gate from live PR labels.
+- `createLabel` attempts return 403 → `labelCreationBlocked = true`, loop
+  breaks cleanly; no phantom labels in the snapshot list.
+- Comment writes return 403 → caught and logged via `core.info`, gate
+  decision is unaffected.
+- Gate fails until a maintainer (or any Calico team member) applies
+  `skip-releases-backport` or a `backport/release-vX.Y` label; once a label
+  is applied, the `labeled` event re-fires the workflow and the gate passes.


### PR DESCRIPTION
## Summary
- Cross-fork PR opened from `skoryk-oleksandr/calico:test/fork-pr-permissions` (sibling fork in the `projectcalico/calico` network) into `tigera/calico-oss-test:master`.
- Purpose: verify `check_backport_labels.yml` behaves correctly under a read-only `GITHUB_TOKEN`, which is what GitHub gives any cross-fork PR.

## What to look for
- Workflow run completes without errors.
- `createLabel` 403s are caught and logged as `core.warning`; no failed run.
- Comment-write 403s are caught and logged as `core.info`; no failed run.
- Gate **fails** initially (no `skip-releases-backport`, no `backport/release-vX.Y` label).
- After a team member applies a label, the `labeled` event re-runs the workflow and the gate **passes**.
- The snapshot list comment (if one is created) includes the fork-PR note about read-only token / `Sync Backport Labels` backfill.

## Test plan
- [ ] Confirm the workflow run is green (or red only because the gate failed by design, not because of an unhandled error).
- [ ] Apply `skip-releases-backport` and confirm the gate flips to passing.
- [ ] Remove the label, apply a `backport/release-vX.Y` label, confirm the gate still passes.
- [ ] Remove all backport-related labels and confirm the gate fails again.
- [ ] Close the PR without merging once the smoke test is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)