### PR TITLE
Single source of truth for backport labels

### DIFF
--- a/.github/workflows/check_backport_labels.yml
+++ b/.github/workflows/check_backport_labels.yml
@@ -1,17 +1,23 @@
 # This workflow gates PR merges on an explicit backport decision:
-# 1. Ensure a 'backport/release-vX.Y' label exists for every release branch
-#    (idempotent — mirrors sync_backport_labels.yml so a label is created at
-#    PR time if the 'create' event on the sister workflow ever misses the
-#    branch). The label-creation logic is duplicated in
-#    sync_backport_labels.yml; keep them in sync (search for CHANGE-BOTH).
-# 2. Post a one-time comment listing the available backport labels. This
-#    comment is never rewritten and carries a snapshot-date disclaimer.
-# 3. Post or update a sticky decision comment that asks for a backport choice
-#    and points reviewers at the list comment above.
-# 4. Fail the check unless the PR has either 'skip-releases-backport' or at
-#    least one 'backport/release-vX.Y' label set. The gate decision is
-#    computed from live PR labels and is never masked by comment-write errors.
-# Add this check to required status checks in branch protection to block merge.
+# 1. Maintain a single sticky comment on each PR that lists the
+#    `backport/release-vX.Y` labels derived from current release branches
+#    AND states whether the PR's labels currently satisfy the gate. The
+#    comment refreshes on every PR event (update-if-changed to avoid
+#    notification churn). If no PR event fires (idle PR across a release
+#    branch cut), the comment stays stale until the next event; the PR
+#    sidebar Labels picker remains authoritative.
+# 2. Fail the check unless the PR has either 'skip-releases-backport' or
+#    at least one 'backport/release-vX.Y' label. The gate decision is
+#    computed from live PR labels and is never masked by comment-write
+#    errors.
+#
+# This workflow does NOT create labels. sync_backport_labels.yml is the
+# single source of truth for the label set; missing labels are healed by
+# its 'create' webhook, its twice-daily schedule, or a manual
+# workflow_dispatch.
+#
+# Add this check to required status checks in branch protection to block
+# merge.
 
 name: Validate Backport Labels
 on:
@@ -51,104 +57,33 @@ jobs:
                                     e.status === 429 ||
                                     e.status === 408 ||
                                     typeof e.status === 'undefined' ||
-                                    e.code === 'ETIMEDOUT' ||
-                                    e.code === 'ECONNRESET' ||
                                     (e.status === 403 && /rate limit|secondary/i.test(e.message || ''));
                   if (!transient || attempt === maxAttempts) throw e;
                   const delayMs = 500 * Math.pow(2, attempt - 1);
-                  core.info(`Transient error on ${label} (status=${e.status}, code=${e.code}); retrying in ${delayMs}ms.`);
+                  core.info(`Transient error on ${label} (status=${e.status}); retrying in ${delayMs}ms.`);
                   await new Promise(r => setTimeout(r, delayMs));
                 }
               }
               throw new Error(`unreachable: withRetry exited loop without returning (${label})`);
             }
 
-            // Label toggles and code pushes cannot create a new release
-            // branch, so skip ref enumeration + createLabel work on those
-            // events to save API budget. The 'create' trigger in
-            // sync_backport_labels.yml covers new release branches. The
-            // gate still uses live labels below.
-            const action = context.payload.action;
-            const skipLabelCreation = action === 'labeled' ||
-                                      action === 'unlabeled' ||
-                                      action === 'synchronize';
-
-            // CHANGE-BOTH: label-creation constants are duplicated in
-            // sync_backport_labels.yml. Keep them in sync.
-            const labelColor = '0e8a16';
-            const labelDescription = 'Cherry-pick this PR to the matching release branch.';
+            // Derive expected backport labels from current release branches.
+            // listMatchingRefs returns any ref starting with the prefix;
+            // branchRe filters out shapes like release-v3.30-hotfix or
+            // release-v4. The label set itself is managed by
+            // sync_backport_labels.yml — this workflow only reads refs.
             const branchRe = /^release-v\d+\.\d+$/;
-
-            let releaseBranches = [];
-            let createdCount = 0;
-            let failedLabelCount = 0;
-            let labelCreationBlocked = false;
-
-            if (!skipLabelCreation) {
-              // listMatchingRefs returns any ref starting with the prefix;
-              // branchRe is the actual correctness guarantee, filtering out
-              // shapes like release-v3.30-hotfix or release-v4.
-              const refs = await github.paginate(github.rest.git.listMatchingRefs, {
-                owner, repo, ref: 'heads/release-v', per_page: 100,
-              });
-              releaseBranches = refs
-                .map(r => r.ref.replace(/^refs\/heads\//, ''))
-                .filter(n => branchRe.test(n));
-            }
-
-            const allLabels = await github.paginate(github.rest.issues.listLabelsForRepo, {
-              owner, repo, per_page: 100,
+            const refs = await github.paginate(github.rest.git.listMatchingRefs, {
+              owner, repo, ref: 'heads/release-v', per_page: 100,
             });
-            const existingLabels = new Set(allLabels.map(l => l.name));
+            const expectedLabels = refs
+              .map(r => r.ref.replace(/^refs\/heads\//, ''))
+              .filter(n => branchRe.test(n))
+              .map(b => `backport/${b}`)
+              .sort();
 
-            if (!skipLabelCreation) {
-              for (const branch of releaseBranches) {
-                const labelName = `backport/${branch}`;
-                if (existingLabels.has(labelName)) continue;
-                core.info(`Creating label: ${labelName}`);
-                let created = false;
-                try {
-                  // CHANGE-BOTH: createLabel is wrapped in withRetry here and
-                  // in sync_backport_labels.yml. Keep both wrapped.
-                  await withRetry(() => github.rest.issues.createLabel({
-                    owner, repo, name: labelName, color: labelColor, description: labelDescription,
-                  }), `createLabel(${labelName})`);
-                  createdCount++;
-                  created = true;
-                } catch (e) {
-                  const alreadyExists = e.status === 422 && (
-                    e.response?.data?.errors?.some(err => err.code === 'already_exists') ||
-                    /already[_ ]exists/i.test(e.message || '')
-                  );
-                  if (alreadyExists) {
-                    // Race with sync_backport_labels.yml — label just created.
-                    created = true;
-                  } else if (e.status === 403) {
-                    // Fork PR — token has no write scope. A maintainer must
-                    // run workflow_dispatch on sync_backport_labels.yml to
-                    // backfill, or open a same-repo PR which can create it.
-                    core.warning(`Cannot create label ${labelName} (403). Run workflow_dispatch on sync_backport_labels.yml to backfill.`);
-                    labelCreationBlocked = true;
-                    break;
-                  } else {
-                    // Per-label resilience: surface but continue so one bad
-                    // label does not block the rest. The next PR event for
-                    // this PR will retry; ops can also workflow_dispatch the
-                    // sync workflow to force a global retry.
-                    core.warning(`Failed to create label ${labelName}: ${e.message}`);
-                    failedLabelCount++;
-                  }
-                }
-                // Only mark as existing if it really does — otherwise the
-                // snapshot list and gate error would advertise labels that
-                // are not actually present in the repo.
-                if (created) existingLabels.add(labelName);
-              }
-            }
-
+            // Gate: read live PR labels.
             const backportRe = /^backport\/release-v\d+\.\d+$/;
-            const available = [...existingLabels].filter(n => backportRe.test(n)).sort();
-
             const liveLabels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
               owner, repo, issue_number: pr.number, per_page: 100,
             });
@@ -157,113 +92,68 @@ jobs:
             const hasBackport = prLabels.some(n => backportRe.test(n));
             const gatePassed = hasNoBackport || hasBackport;
 
-            const listMarker = '<!-- backport-label-list -->';
-            const decisionMarker = '<!-- backport-label-bot -->';
+            // Build the single sticky comment body.
+            const marker = '<!-- backport-label-bot -->';
+            const lines = [marker, '### Backport labels', ''];
+            if (expectedLabels.length === 0) {
+              lines.push('_No `release-vX.Y` branches currently exist; no backport labels apply._');
+            } else {
+              for (const n of expectedLabels) lines.push(`- \`${n}\``);
+            }
+            lines.push('');
+            lines.push('_This list reflects release branches at the time of the last update to this comment; the PR sidebar Labels picker is always authoritative._');
+            lines.push('');
+            lines.push('---');
+            lines.push('');
+            if (gatePassed) {
+              lines.push('Backport decision recorded.');
+            } else {
+              lines.push('This PR is missing a backport decision. Add **`skip-releases-backport`** or one of the `backport/release-vX.Y` labels above.');
+            }
+            const body = lines.join('\n');
 
             try {
-              let comments = await github.paginate(github.rest.issues.listComments, {
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 owner, repo, issue_number: pr.number, per_page: 100,
               });
               // Defensive sort: the Issues comments API does not formally
               // document its ordering. Comment IDs are monotonic.
               comments.sort((a, b) => a.id - b.id);
+              const matches = comments.filter(c => c.body && c.body.startsWith(marker));
 
-              if (!comments.some(c => c.body && c.body.startsWith(listMarker))) {
-                // Narrow the race window: re-read immediately before create.
-                const recheckPre = await github.paginate(github.rest.issues.listComments, {
-                  owner, repo, issue_number: pr.number, per_page: 100,
-                });
-                if (!recheckPre.some(c => c.body && c.body.startsWith(listMarker))) {
-                  // toISOString always returns UTC; do not switch to toLocaleDateString.
-                  const snapshotDate = new Date().toISOString().slice(0, 10);
-                  const listLines = [
-                    listMarker,
-                    '### Available backport labels',
-                    '',
-                    `_Snapshot taken ${snapshotDate} (UTC); this list is not refreshed — new release branches may have been added since._`,
-                    '',
-                  ];
-                  if (available.length === 0) {
-                    listLines.push('_No `backport/release-vX.Y` labels are currently defined in this repo._');
-                  } else {
-                    // Filtered through backportRe above; safe to interpolate.
-                    for (const n of available) listLines.push(`- \`${n}\``);
-                  }
-                  if (labelCreationBlocked) {
-                    listLines.push('');
-                    listLines.push('_Note: this run had a read-only token (likely a fork PR), so any missing `backport/release-vX.Y` labels could not be created. A maintainer can run the `Sync Backport Labels` workflow via `workflow_dispatch` to backfill._');
-                  }
-                  await withRetry(() => github.rest.issues.createComment({
-                    owner, repo, issue_number: pr.number, body: listLines.join('\n'),
-                  }), 'createComment(list)');
-                  // Self-healing across runs. Concurrent runs in the same
-                  // window can temporarily create duplicates; subsequent
-                  // runs see all of them, keep the oldest by id, and delete
-                  // the rest. Concurrent delete calls on the same victim id
-                  // are idempotent (one succeeds, others 404 and are caught
-                  // below).
-                  const recheckPost = await github.paginate(github.rest.issues.listComments, {
-                    owner, repo, issue_number: pr.number, per_page: 100,
-                  });
-                  const dupes = recheckPost
-                    .filter(c => c.body && c.body.startsWith(listMarker))
-                    .sort((a, b) => a.id - b.id);
-                  for (const dup of dupes.slice(1)) {
-                    try {
-                      await withRetry(() => github.rest.issues.deleteComment({
-                        owner, repo, comment_id: dup.id,
-                      }), 'deleteComment(list-dup)');
-                      core.info(`Deleted duplicate list comment ${dup.id}.`);
-                    } catch (e) {
-                      core.warning(`Could not delete duplicate list comment ${dup.id}: ${e.message}`);
-                    }
-                  }
-                  comments = recheckPost;
-                } else {
-                  comments = recheckPre;
-                }
-                comments.sort((a, b) => a.id - b.id);
-              }
-
-              const decisionMatches = comments.filter(c => c.body && c.body.startsWith(decisionMarker));
-              const decisionLines = [decisionMarker, '### Backport label check', ''];
-              if (gatePassed) {
-                decisionLines.push('Backport decision recorded.');
-              } else {
-                decisionLines.push('This PR is missing a backport decision. Add **`skip-releases-backport`** or one of the `backport/release-vX.Y` labels listed in the comment above.');
-              }
-              const decisionBody = decisionLines.join('\n');
-
-              // Delete extras FIRST so the screen state is correct even if the
-              // run is killed between deletes and the update below.
-              if (decisionMatches.length > 1) {
-                core.warning(`Found ${decisionMatches.length} decision comments; deleting ${decisionMatches.length - 1} extras.`);
-                for (const extra of decisionMatches.slice(1)) {
+              // Delete extras FIRST so screen state is correct even if the
+              // run is killed before the update below. Concurrent runs are
+              // serialized by the workflow's per-PR concurrency group, so
+              // racing on the same PR shouldn't happen — but if it ever did,
+              // the dedupe + 404-tolerant update path below recovers.
+              if (matches.length > 1) {
+                core.warning(`Found ${matches.length} bot comments; deleting ${matches.length - 1} extras.`);
+                for (const extra of matches.slice(1)) {
                   try {
                     await withRetry(() => github.rest.issues.deleteComment({
                       owner, repo, comment_id: extra.id,
-                    }), 'deleteComment(decision-dup)');
+                    }), 'deleteComment(dup)');
                   } catch (e) {
-                    core.warning(`Could not delete extra decision comment ${extra.id}: ${e.message}`);
+                    core.warning(`Could not delete extra bot comment ${extra.id}: ${e.message}`);
                   }
                 }
               }
 
-              const oldest = decisionMatches[0];
+              const oldest = matches[0];
               if (oldest) {
-                if (oldest.body === decisionBody) {
-                  core.info('Decision comment unchanged; skipping update to avoid notification churn.');
+                if (oldest.body === body) {
+                  core.info('Bot comment unchanged; skipping update to avoid notification churn.');
                 } else {
                   try {
                     await withRetry(() => github.rest.issues.updateComment({
-                      owner, repo, comment_id: oldest.id, body: decisionBody,
-                    }), 'updateComment(decision)');
+                      owner, repo, comment_id: oldest.id, body,
+                    }), 'updateComment');
                   } catch (e) {
                     if (e.status === 404) {
                       // Sticky deleted between read and write — recreate.
                       await withRetry(() => github.rest.issues.createComment({
-                        owner, repo, issue_number: pr.number, body: decisionBody,
-                      }), 'createComment(decision)');
+                        owner, repo, issue_number: pr.number, body,
+                      }), 'createComment');
                     } else {
                       throw e;
                     }
@@ -271,8 +161,8 @@ jobs:
                 }
               } else {
                 await withRetry(() => github.rest.issues.createComment({
-                  owner, repo, issue_number: pr.number, body: decisionBody,
-                }), 'createComment(decision)');
+                  owner, repo, issue_number: pr.number, body,
+                }), 'createComment');
               }
             } catch (e) {
               if (e.status === 403) {
@@ -287,21 +177,11 @@ jobs:
               }
             }
 
-            let creationSummary;
-            if (skipLabelCreation) {
-              // releaseBranches/createdCount are 0 by skip, not by truth — omit
-              // them so the log does not read as "we tried and found nothing."
-              creationSummary = `label-creation skipped (${action} event)`;
-            } else {
-              const forkNote = labelCreationBlocked ? ' (blocked early — fork PR)' : '';
-              const failNote = failedLabelCount ? `, label-create failures: ${failedLabelCount}` : '';
-              creationSummary = `release branches: ${releaseBranches.length}, labels created: ${createdCount}${failNote}${forkNote}`;
-            }
-            core.info(`${creationSummary}, available backport labels: ${available.length}, gate ${gatePassed ? 'passed' : 'failed'}.`);
+            core.info(`release branches: ${expectedLabels.length}, gate ${gatePassed ? 'passed' : 'failed'}.`);
 
             if (!gatePassed) {
-              const inline = available.length === 0
-                ? '(no backport labels currently defined)'
-                : available.map(n => `\`${n}\``).join(', ');
+              const inline = expectedLabels.length === 0
+                ? '(no release branches currently exist)'
+                : expectedLabels.map(n => `\`${n}\``).join(', ');
               core.setFailed(`PR must have either \`skip-releases-backport\` or a \`backport/release-vX.Y\` label. Available: ${inline}. PR: ${pr.html_url}`);
             }

--- a/.github/workflows/sync_backport_labels.yml
+++ b/.github/workflows/sync_backport_labels.yml
@@ -1,22 +1,29 @@
 # Reconciles 'backport/release-vX.Y' labels with the set of 'release-vX.Y'
-# branches that currently exist in the repo.
+# branches that currently exist in the repo. This workflow is the single
+# source of truth for the backport-label set; check_backport_labels.yml
+# only reads release branches to render its PR comment and does not create
+# labels.
 #
 # Behavior: creates missing labels. Does NOT delete stale labels, so that
 # historic PRs keep their labels intact for audit purposes. If a release
 # branch is retired, archive its label manually.
 #
-# Triggers: on branch creation (covers new release cuts) and manual dispatch.
-# There is intentionally no scheduled run — label creation relies on the
-# 'create' webhook for new branches, with check_backport_labels.yml as a
-# PR-time safety net. Use workflow_dispatch to backfill if a 'create' event
-# is ever missed (e.g., Actions outage).
-#
-# Note: check_backport_labels.yml runs the same label-creation logic at PR
-# time. Keep both in sync (search for CHANGE-BOTH).
+# Three triggers:
+# 1. 'create' webhook — primary path. Fires when a branch is pushed; the
+#    job's `if:` filters to 'release-v*' so a label is created the moment
+#    a release branch is cut.
+# 2. 'schedule' (06:00 and 18:00 UTC) — automatic recovery. Heals missing
+#    labels if a 'create' event was ever lost (Actions outage, branch
+#    created via an API call that didn't fire 'create', etc.). Cheap:
+#    typically zero createLabel calls because nothing is missing.
+# 3. 'workflow_dispatch' — manual recovery. Any team member can force an
+#    immediate backfill instead of waiting for the next scheduled run.
 
 name: Sync Backport Labels
 on:
   create:
+  schedule:
+    - cron: '0 6,18 * * *'
   workflow_dispatch:
 
 # Single global key by design: serializes the branch-create event and any
@@ -54,12 +61,10 @@ jobs:
                                     e.status === 429 ||
                                     e.status === 408 ||
                                     typeof e.status === 'undefined' ||
-                                    e.code === 'ETIMEDOUT' ||
-                                    e.code === 'ECONNRESET' ||
                                     (e.status === 403 && /rate limit|secondary/i.test(e.message || ''));
                   if (!transient || attempt === maxAttempts) throw e;
                   const delayMs = 500 * Math.pow(2, attempt - 1);
-                  core.info(`Transient error on ${label} (status=${e.status}, code=${e.code}); retrying in ${delayMs}ms.`);
+                  core.info(`Transient error on ${label} (status=${e.status}); retrying in ${delayMs}ms.`);
                   await new Promise(r => setTimeout(r, delayMs));
                 }
               }
@@ -81,8 +86,6 @@ jobs:
             });
             const existing = new Set(labels.map(l => l.name));
 
-            // CHANGE-BOTH: label-creation constants are duplicated in
-            // check_backport_labels.yml. Keep them in sync.
             const labelColor = '0e8a16';
             const labelDescription = 'Cherry-pick this PR to the matching release branch.';
 
@@ -103,11 +106,13 @@ jobs:
                   /already[_ ]exists/i.test(e.message || '')
                 );
                 if (alreadyExists) {
-                  // Race with check_backport_labels.yml — label just created.
+                  // Race with another sync run (concurrent create + schedule
+                  // window) — label is already present, treat as success.
                 } else {
                   // Per-label resilience: surface but continue so one bad
-                  // label does not poison the rest. There is no scheduled
-                  // retry — operator must rerun via workflow_dispatch.
+                  // label does not poison the rest. The next scheduled run
+                  // will retry; operators can also force a retry via
+                  // workflow_dispatch.
                   core.warning(`Failed to create label ${labelName}: ${e.message}`);
                   failedCount++;
                 }
@@ -115,5 +120,5 @@ jobs:
             }
             core.info(`Release branches: ${releaseBranches.length}, labels created: ${createdCount}, failures: ${failedCount}.`);
             if (failedCount > 0) {
-              core.warning(`${failedCount} label(s) failed to create. There is no scheduled retry — rerun this workflow via workflow_dispatch to backfill.`);
+              core.warning(`${failedCount} label(s) failed to create. The next scheduled run will retry; use workflow_dispatch to retry immediately.`);
             }


### PR DESCRIPTION
## Summary
- **`sync_backport_labels.yml`** is now the only writer of backport labels. Adds a twice-daily schedule trigger (06:00/18:00 UTC) so missed `create` events self-heal without operator action.
- **`check_backport_labels.yml`** no longer creates labels. It derives the expected `backport/release-vX.Y` set from current release branches and renders **one** sticky bot comment that combines the list and the gate decision. The comment refreshes on every PR event (update-if-changed to avoid notification churn).
- Drops a lot of now-unused machinery: `skipLabelCreation`, `labelCreationBlocked`, `failedLabelCount`, the two-comment dedupe logic, the snapshot-date disclaimer, the `CHANGE-BOTH` markers, the deprecation-noisy `e.code` checks in `withRetry`.

Net diff: **-216 / +101**.

## Recovery contract for the label set
1. `create` webhook fires on a `release-v*` branch push → sync creates the label immediately.
2. If that event is ever lost, the **twice-daily schedule** heals it.
3. Anyone can force an immediate backfill via `workflow_dispatch` on `Sync Backport Labels`.

## Known limitation
If a PR sits idle across a release-branch cut, its sticky comment stays stale until the next PR event. The PR sidebar Labels picker remains authoritative; this is called out in both the comment and the workflow header. Deemed acceptable given Calico's release cadence (months between cuts).

## Test plan
- [ ] Open a same-repo PR against `master` and confirm the sticky comment appears with the current release-vX.Y list and a pass/fail message.
- [ ] Toggle `skip-releases-backport` and confirm the comment updates (gate flips) without notification churn on unrelated re-runs.
- [ ] Open a cross-fork PR (read-only token) and confirm: workflow completes, no `createLabel` 403 noise, comment write 403 is caught and logged, gate still fails by design.
- [ ] Trigger `Sync Backport Labels` via `workflow_dispatch` and confirm a clean run with `labels created: 0`.
- [ ] Verify the scheduled run lands at 06:00/18:00 UTC after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)