### PR TITLE
Test: verify check_backport_labels after refactor

### DIFF
--- a/verify-check-backport-2026-05-20.md
+++ b/verify-check-backport-2026-05-20.md
@@ -1,0 +1,19 @@
+# Verify check_backport_labels.yml (2026-05-20)
+
+Smoke test for the refactored PR check workflow after merging #126.
+
+Expected:
+- Single sticky bot comment appears with the marker
+  `<!-- backport-label-bot -->`, listing the `backport/release-vX.Y`
+  labels derived from current release branches.
+- Initial gate state: fail (no decision label applied).
+- Apply `skip-releases-backport` → workflow re-runs on `labeled`
+  event → comment updates to "Backport decision recorded." and gate
+  flips to passing.
+- Remove that label and apply `backport/release-v3.31` → comment
+  stays at pass, gate stays passing.
+- Remove all backport-related labels → comment goes back to the
+  "missing decision" message, gate fails.
+- During no-op re-runs (e.g., re-triggering with the same label set),
+  the workflow log says "Bot comment unchanged; skipping update to
+  avoid notification churn."


### PR DESCRIPTION
## Summary
Same-repo PR opened to verify the refactored `check_backport_labels.yml` workflow end-to-end after #126.

## What to look for
- One sticky bot comment with marker `<!-- backport-label-bot -->`.
- The comment lists `backport/release-v*` labels derived from current release branches.
- Initial gate state: **fail** (no decision label).
- After applying `skip-releases-backport` (or any `backport/release-v*`), the `labeled` event re-fires the workflow, the comment updates to "Backport decision recorded.", and the check turns green.
- Removing the decision label flips it back.
- On no-op re-runs (same label set), workflow log shows `Bot comment unchanged; skipping update to avoid notification churn.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)