### PR TITLE
Diagnostic: log API URL on caught comment-block errors

### DIFF
--- a/.github/workflows/check_backport_labels.yml
+++ b/.github/workflows/check_backport_labels.yml
@@ -166,14 +166,19 @@ jobs:
               }
             } catch (e) {
               if (e.status === 403) {
-                core.info('Comment writes skipped (no write token, likely fork PR). Gate result is unaffected.');
+                // Could be a true read-only fork-PR token OR a different 403
+                // (org policy, secondary rate limit that didn't match the
+                // retry regex, etc.). Log the message + request URL so the
+                // distinction is visible in the run log without breaking
+                // the gate.
+                core.info(`Comment writes skipped (403 on ${e.request?.method || '?'} ${e.request?.url || '?'}: ${e.message}). Gate result is unaffected.`);
               } else if (e.status === 404 || e.status === 409 || e.status === 429 ||
                          (e.status >= 500 && e.status < 600)) {
-                core.warning(`Comment-write API error (${e.status}): ${e.message}. Gate result is unaffected.`);
+                core.warning(`Comment-write API error (${e.status}) on ${e.request?.method || '?'} ${e.request?.url || '?'}: ${e.message}. Gate result is unaffected.`);
               } else {
                 // Unknown error class — surface as an annotation so bugs are
                 // loud, but do not mask the gate decision computed above.
-                core.error(`Unexpected error in comment block: ${e.message}\n${e.stack || ''}`);
+                core.error(`Unexpected error in comment block (status=${e.status}) on ${e.request?.method || '?'} ${e.request?.url || '?'}: ${e.message}\n${e.stack || ''}`);
               }
             }
 


### PR DESCRIPTION
## Summary
- On test PR #127 (a same-repo PR with `Issues: write`), the comment-block catch fired with the static "Comment writes skipped (no write token, likely fork PR)" message. That message lies — the token had write — but the script hides the actual HTTP method/URL/error message, so we can't tell why a 403 happened.
- This change surfaces `e.request.method`, `e.request.url`, and `e.message` in all three catch branches so the next run tells us exactly which API call 403'd and what GitHub's reason was.
- No change to gate semantics or retry behavior. Pure diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)