### PR TITLE
Fix: restore pull-requests:write so PR comments stop 403ing

### DIFF
--- a/.github/workflows/check_backport_labels.yml
+++ b/.github/workflows/check_backport_labels.yml
@@ -38,7 +38,13 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-      issues: write
+      # GitHub App tokens (including the workflow GITHUB_TOKEN) require
+      # 'pull-requests: write' to comment on a PR, even though the API
+      # endpoint is /repos/.../issues/.../comments. 'issues: write' alone
+      # produces a 403 "Resource not accessible by integration" on the
+      # POST. The /issues URL path is shared with real issues, but the
+      # GitHub App permission is split by target type.
+      pull-requests: write
     steps:
       - name: Check backport labels and update comment
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
Diagnostic from #128 showed same-repo PR runs were emitting `403 Resource not accessible by integration` on `POST /repos/tigera/calico-oss-test/issues/127/comments`. The token had `Issues: write`, but **GitHub App tokens — including `GITHUB_TOKEN` — split the underlying permission by target type**: `issues: write` only covers comments on real issues; PR comments require `pull-requests: write`, even though the URL is shared.

#124 dropped `pull-requests: write` under the wrong assumption that `issues: write` covered both. Same-repo PRs have been failing to render the sticky comment ever since (fork PRs were already broken for a different reason, which hid the regression).

This PR restores `pull-requests: write` and adds an inline comment explaining the gotcha so the same mistake doesn't recur.

## Test plan
- [ ] Merge.
- [ ] Push an empty commit to test PR #127 — sticky comment should now appear.
- [ ] Toggle `skip-releases-backport` on #127 — comment should update to "Backport decision recorded." and the check turns green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)