### PR TITLE
Address backport-label review findings (H1, H3, H4, M4, M7, M8)

### DIFF
--- a/.github/workflows/check_backport_labels.yml
+++ b/.github/workflows/check_backport_labels.yml
@@ -9,7 +9,9 @@ name: Validate Backport Labels
 # never check out the PR head or run PR-controlled content.
 on:
   pull_request_target:
-    types: [opened, reopened, labeled, unlabeled, synchronize, ready_for_review]
+    # No `synchronize` — re-running on every PR push wastes API budget;
+    # neither labels nor release branches can change on a push.
+    types: [opened, reopened, labeled, unlabeled, ready_for_review]
 
 concurrency:
   group: backport-labels-${{ github.event.pull_request.number }}
@@ -31,6 +33,9 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const pr = context.payload.pull_request;
+            // Same-repo vs fork PR: fork PRs always get a read-only token,
+            // so 403s on writes are expected. Same-repo 403s are not.
+            const isFork = pr.head?.repo?.full_name !== `${owner}/${repo}`;
 
             async function withRetry(fn, label) {
               const maxAttempts = 3;
@@ -99,20 +104,9 @@ jobs:
               comments.sort((a, b) => a.id - b.id);
               const matches = comments.filter(c => c.body && c.body.startsWith(marker));
 
-              // Delete extras before update so a killed run leaves a clean state.
-              if (matches.length > 1) {
-                core.warning(`Found ${matches.length} bot comments; deleting ${matches.length - 1} extras.`);
-                for (const extra of matches.slice(1)) {
-                  try {
-                    await withRetry(() => github.rest.issues.deleteComment({
-                      owner, repo, comment_id: extra.id,
-                    }), 'deleteComment(dup)');
-                  } catch (e) {
-                    core.warning(`Could not delete extra bot comment ${extra.id}: ${e.message}`);
-                  }
-                }
-              }
-
+              // Update the oldest sticky FIRST, then delete extras. If the
+              // delete step fails mid-flight the PR has duplicate stickies
+              // (cosmetic), but never zero stickies.
               const oldest = matches[0];
               if (oldest) {
                 if (oldest.body === body) {
@@ -138,15 +132,33 @@ jobs:
                   owner, repo, issue_number: pr.number, body,
                 }), 'createComment');
               }
+
+              if (matches.length > 1) {
+                core.warning(`Found ${matches.length} bot comments; deleting ${matches.length - 1} extras.`);
+                for (const extra of matches.slice(1)) {
+                  try {
+                    await withRetry(() => github.rest.issues.deleteComment({
+                      owner, repo, comment_id: extra.id,
+                    }), 'deleteComment(dup)');
+                  } catch (e) {
+                    core.warning(`Could not delete extra bot comment ${extra.id}: ${e.message}`);
+                  }
+                }
+              }
             } catch (e) {
-              // Log method/URL to distinguish fork-token 403s from policy/rate-limit 403s.
-              if (e.status === 403) {
-                core.info(`Comment writes skipped (403 on ${e.request?.method || '?'} ${e.request?.url || '?'}: ${e.message}). Gate result is unaffected.`);
+              const where = `${e.request?.method || '?'} ${e.request?.url || '?'}`;
+              if (e.status === 403 && isFork) {
+                // Expected on fork PRs (read-only token). Log at info.
+                core.info(`Comment writes skipped (403 on ${where}: ${e.message}). Gate result is unaffected.`);
+              } else if (e.status === 403) {
+                // Same-repo 403 is NOT expected — likely org policy or a
+                // narrowed token. Surface it.
+                core.warning(`Unexpected 403 on same-repo PR (${where}: ${e.message}). Gate result is unaffected.`);
               } else if (e.status === 404 || e.status === 409 || e.status === 429 ||
                          (e.status >= 500 && e.status < 600)) {
-                core.warning(`Comment-write API error (${e.status}) on ${e.request?.method || '?'} ${e.request?.url || '?'}: ${e.message}. Gate result is unaffected.`);
+                core.warning(`Comment-write API error (${e.status}) on ${where}: ${e.message}. Gate result is unaffected.`);
               } else {
-                core.error(`Unexpected error in comment block (status=${e.status}) on ${e.request?.method || '?'} ${e.request?.url || '?'}: ${e.message}\n${e.stack || ''}`);
+                core.error(`Unexpected error in comment block (status=${e.status}) on ${where}: ${e.message}\n${e.stack || ''}`);
               }
             }
 

--- a/.github/workflows/sync_backport_labels.yml
+++ b/.github/workflows/sync_backport_labels.yml
@@ -4,7 +4,10 @@
 #
 # Triggers: 'create' (primary, on release-v* branch push), 'schedule' (twice
 # daily, auto-recovery for missed 'create' events), 'workflow_dispatch'
-# (manual recovery).
+# (manual recovery; also the recommended hook for release-cutting automation
+# — 'create' is suppressed for branches pushed using the default
+# GITHUB_TOKEN, so a workflow that cuts release branches should invoke this
+# workflow via workflow_dispatch right after).
 
 name: Sync Backport Labels
 on:
@@ -83,11 +86,10 @@ jobs:
                 }), `createLabel(${labelName})`);
                 createdCount++;
               } catch (e) {
-                const alreadyExists = e.status === 422 && (
-                  e.response?.data?.errors?.some(err => err.code === 'already_exists') ||
-                  /already[_ ]exists/i.test(e.message || '')
-                );
-                if (alreadyExists) {
+                // 422 only happens here on name collision — color is a
+                // hardcoded valid hex and the name is derived from a
+                // branchRe-filtered ref. Treat 422 as the concurrent-run race.
+                if (e.status === 422) {
                   // Concurrent sync run beat us to it — treat as success.
                 } else {
                   // Surface and continue; the next scheduled run retries.
@@ -98,5 +100,8 @@ jobs:
             }
             core.info(`Release branches: ${releaseBranches.length}, labels created: ${createdCount}, failures: ${failedCount}.`);
             if (failedCount > 0) {
-              core.warning(`${failedCount} label(s) failed to create. The next scheduled run will retry; use workflow_dispatch to retry immediately.`);
+              // Red run so partial syncs surface in the Actions tab. The
+              // next scheduled run will retry; use workflow_dispatch for
+              // an immediate retry.
+              core.setFailed(`${failedCount} label(s) failed to create.`);
             }


### PR DESCRIPTION
## Summary
Six findings from the independent review:

**check_backport_labels.yml**
- **H1** — Drop `synchronize` from `pull_request_target.types`. Re-running the full job on every PR push wasted API budget; nothing it inspects can change on a push.
- **H3** — Same-repo 403s in the comment block now warn instead of being demoted to info. Fork-PR 403s still log at info (expected, read-only token). Detection uses `pr.head.repo.full_name`.
- **M4** — Reorder the dedupe: update the oldest sticky first, then delete extras. A mid-flight failure now leaves duplicates (cosmetic) instead of possibly zero comments.

**sync_backport_labels.yml**
- **H4** — Document that `create` is suppressed for branches pushed by a workflow using `GITHUB_TOKEN`, and call out `workflow_dispatch` as the recommended hook for release-cutting automation.
- **M7** — Simplify the `createLabel` catch: `e.status === 422` is sufficient. Color is a hardcoded valid hex; name comes from a `branchRe`-filtered ref. Drop the `data.errors` / message regex sniff.
- **M8** — `setFailed` on partial syncs so they surface as red runs.

## Skipped from the review
The remaining medium / low / nit items (M1, M2, M3, M5, M6, M9 and the L-band) are taste or hypothetical scale.

## Test plan
- [ ] Same-repo PR: confirm the sticky still posts, label toggles flip the gate, and `synchronize` events no longer trigger workflow runs (push a commit to any open PR with the workflow running on this branch).
- [ ] Fork PR: confirm 403 still logs at info via `isFork` path.
- [ ] Sync workflow_dispatch: confirm a clean run still ends with a green check.
- [ ] If feasible, induce a partial sync (e.g. delete one backport label, then revoke labels:write on the App momentarily): confirm the workflow turns red and the error annotation surfaces.