### PR TITLE
Use commit status API instead of check_runs

### DIFF
--- a/.github/workflows/backport_labels.yml
+++ b/.github/workflows/backport_labels.yml
@@ -1,16 +1,16 @@
 # Stage 2 of the backport-labels gate. Triggered by workflow_run when
 # "Backport Labels (trigger)" completes. Runs from the base branch (trusted
-# workflow file) with issues:write and checks:write so it can create
-# missing backport labels and post the required-status check_run on the
-# PR head SHA.
+# workflow file) with issues:write and statuses:write so it can create
+# missing backport labels and post the required commit status on the PR
+# head SHA.
 #
 # Trust model: stage 1 may execute fork-modified code from the PR head, but
 # it holds no token writes and no secrets. Stage 2 derives PR identity from
 # GitHub-set workflow_run.head_sha, never from artifact content, so a fork
 # cannot trick stage 2 into acting on a different PR.
 #
-# Branch protection should require the "validate-backport-labels" check
-# (the name posted by checks.create below), not the workflow itself.
+# Branch protection should require the "validate-backport-labels" status
+# context, not the workflow itself.
 
 name: Backport Labels
 on:
@@ -33,7 +33,7 @@ jobs:
       contents: read
       pull-requests: read
       issues: write
-      checks: write
+      statuses: write
     steps:
       # workflow_run runs in the context of the base branch, so checkout
       # without a `ref:` arg gets the default branch's trusted tree, not the

--- a/.github/workflows/scripts/backport_labels.js
+++ b/.github/workflows/scripts/backport_labels.js
@@ -125,37 +125,21 @@ module.exports = async ({ github, context, core }) => {
     core.info(`Missing decision. Add: skip-releases-backport or one of: ${expectedLabels.join(', ')}`);
   }
 
-  // Step 4: Post check_run for branch protection
-  const inline = expectedLabels.map(n => `\`${n}\``).join(', ');
-  const conclusion = gatePassed ? 'success' : 'failure';
-  const checkTitle = gatePassed
-    ? 'Backport decision recorded'
-    : 'Backport decision missing';
-  const checkSummary = gatePassed
-    ? 'PR carries a valid backport decision label.'
-    : `Add \`skip-releases-backport\` or one of the live backport labels. Available: ${inline}.`;
-  const checkName = 'validate-backport-labels';
-  const checkOutput = { title: checkTitle, summary: checkSummary };
-  try {
-    const existing = await withRetry(() => github.rest.checks.listForRef({
-      owner, repo,
-      ref: pr.head.sha,
-      check_name: checkName,
-    }), 'checks.listForRef');
-    const latest = existing.data.check_runs[0];
-    const result = { status: 'completed', conclusion, output: checkOutput };
-    if (latest) {
-      await withRetry(() => github.rest.checks.update({
-        owner, repo, check_run_id: latest.id, ...result,
-      }), 'checks.update');
-    } else {
-      await withRetry(() => github.rest.checks.create({
-        owner, repo, name: checkName, head_sha: pr.head.sha, ...result,
-      }), 'checks.create');
-    }
-  } catch (e) {
-    core.error(`Failed to post check_run: ${e.message}`);
-  }
+  // Step 4: Post commit status for branch protection
+  // Branch protection's merge widget reads commit statuses, not check_runs,
+  // so we post a status here. Status description is capped at 140 chars by
+  // GitHub; the target_url points at this run's log for full detail.
+  const description = gatePassed
+    ? 'Backport decision recorded.'
+    : 'Backport decision missing. See details for the live label list.';
+  await withRetry(() => github.rest.repos.createCommitStatus({
+    owner, repo,
+    sha: pr.head.sha,
+    state: gatePassed ? 'success' : 'failure',
+    context: 'validate-backport-labels',
+    description,
+    target_url: `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+  }), 'createCommitStatus');
 
   core.info(`PR #${pr.number}: live branches=${expectedLabels.length}, gate ${gatePassed ? 'passed' : 'failed'}.`);
 };


### PR DESCRIPTION
Branch protection's merge widget reads the legacy commit statuses API, not check_runs. PRs were stuck with 'Expected — Waiting for status to be reported' because our checks.create call only posted check_runs, never a commit status. Switch to repos.createCommitStatus. Also simpler: no listForRef + update-or-create. Permissions: drop checks:write, add statuses:write.