### PR TITLE
Restore pull-requests:write for info comment

### DIFF
--- a/.github/workflows/backport_labels.yml
+++ b/.github/workflows/backport_labels.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: write
       statuses: write
     steps:


### PR DESCRIPTION
Posting the one-time info comment fails with 'Resource not accessible by integration' because the workflow has pull-requests:read. PR comments require write.