### PR TITLE
Bold backport label names in info comment, drop redundant clause

### DIFF
--- a/.github/workflows/scripts/backport_labels.js
+++ b/.github/workflows/scripts/backport_labels.js
@@ -125,26 +125,6 @@ module.exports = async ({ github, context, core }) => {
     core.info(`Missing decision. Add: skip-releases-backport or one of: ${expectedLabels.join(', ')}`);
   }
 
-  // Job summary shown on the workflow run page so reviewers/authors do not
-  // have to expand the step log to see the gate state and available labels.
-  await core.summary
-    .addHeading('Backport Labels Gate', 2)
-    .addRaw(`**Result:** ${gatePassed ? 'PASSED' : 'FAILED'}`)
-    .addBreak()
-    .addRaw(`**PR:** [#${pr.number}](${pr.html_url})`)
-    .addBreak()
-    .addRaw(`**Head SHA:** \`${pr.head.sha.slice(0, 10)}\``)
-    .addHeading('PR labels', 3)
-    .addList(prLabels.length === 0 ? ['(none)'] : prLabels)
-    .addHeading('Live backport labels (6-month window)', 3)
-    .addList(expectedLabels)
-    .addRaw(
-      gatePassed
-        ? '_PR carries a valid backport decision label._'
-        : '_Add `skip-releases-backport` or one of the live backport labels above to pass the gate._'
-    )
-    .write();
-
   // Step 4: One-time info comment listing the live backport labels.
   // Posted exactly once per PR; we do NOT update it on label changes (the
   // commit status and job summary carry the live state).

--- a/.github/workflows/scripts/backport_labels.js
+++ b/.github/workflows/scripts/backport_labels.js
@@ -158,14 +158,14 @@ module.exports = async ({ github, context, core }) => {
       c.body && c.body.startsWith(infoMarker)
     );
     if (!alreadyPosted) {
-      const labelLines = expectedLabels.map(n => `  - \`${n}\``).join('\n');
+      const labelLines = expectedLabels.map(n => `  - **\`${n}\`**`).join('\n');
       const body = `${infoMarker}
 ### Backport labels for this PR
 
 This PR is gated by the \`validate-backport-labels\` check. To satisfy it, add one of:
 
 - **\`skip-releases-backport\`** if no backport is needed
-- One of the live release backport labels (commit in the last 6 months):
+- One of the live release backport labels:
 ${labelLines}
 
 _This comment is posted once when the PR opens. The current gate state lives on the \`validate-backport-labels\` check below, not here._


### PR DESCRIPTION
Cosmetic tweaks to the one-time info comment:
- Bold each backport/release-vX.Y entry so they match the formatting of skip-releases-backport above.
- Remove the parenthetical '(commit in the last 6 months)' clause.