### PR TITLE
Restore job summary on the workflow run page

### DIFF
--- a/.github/workflows/scripts/backport_labels.js
+++ b/.github/workflows/scripts/backport_labels.js
@@ -116,20 +116,6 @@ module.exports = async ({ github, context, core }) => {
   const hasBackport = prLabels.some(n => backportRe.test(n));
   const gatePassed = hasNoBackport || hasBackport;
 
-  // Log the gate state to the action log. The PR author reaches it by
-  // clicking "Details" on the validate-backport-labels check. Plain text
-  // only; GitHub does not render markdown in action logs.
-  core.info('=== Backport Labels Gate ===');
-  core.info(`PR:                    #${pr.number} (${pr.html_url})`);
-  core.info(`Head SHA:              ${pr.head.sha}`);
-  core.info(`PR labels:             ${prLabels.length === 0 ? '(none)' : prLabels.join(', ')}`);
-  core.info(`Live backport labels:  ${expectedLabels.join(', ')}`);
-  core.info(`Gate:                  ${gatePassed ? 'PASSED' : 'FAILED'}`);
-  if (!gatePassed) {
-    core.info(`Action needed:         add skip-releases-backport or one of: ${expectedLabels.join(', ')}`);
-  }
-  core.info('============================');
-
   // Job summary so the gate result and labels show up directly on the
   // workflow run page (markdown renders here, unlike step logs).
   await core.summary

--- a/.github/workflows/scripts/backport_labels.js
+++ b/.github/workflows/scripts/backport_labels.js
@@ -130,6 +130,22 @@ module.exports = async ({ github, context, core }) => {
   }
   core.info('============================');
 
+  // Job summary so the gate result and labels show up directly on the
+  // workflow run page (markdown renders here, unlike step logs).
+  await core.summary
+    .addHeading('Backport Labels Gate', 2)
+    .addRaw(`**Result:** ${gatePassed ? 'PASSED' : 'FAILED'}`)
+    .addHeading('PR labels', 3)
+    .addList(prLabels.length === 0 ? ['(none)'] : prLabels)
+    .addHeading('Live backport labels', 3)
+    .addList(expectedLabels)
+    .addRaw(
+      gatePassed
+        ? ''
+        : '\n_Add `skip-releases-backport` or one of the live backport labels above to pass the gate._'
+    )
+    .write();
+
   // Step 4: One-time info comment listing the live backport labels.
   // Posted exactly once per PR; we do NOT update it on label changes (the
   // commit status is the source of truth for the live state).


### PR DESCRIPTION
Bring back the job-summary panel (minus PR link and head SHA) so the gate result and labels are visible directly on the run page without expanding the step log.