### PR TITLE
Grant pull-requests: write to cherry-pick-candidate workflow

### DIFF
--- a/.github/workflows/cherry_pick_candidate.yml
+++ b/.github/workflows/cherry_pick_candidate.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: write
     env:
       AGENT_URL: ${{ secrets.BACKPORT_CLASSIFIER_AGENT_URL }}


### PR DESCRIPTION
The Apply-label step in `cherry_pick_candidate.yml` failed with HTTP 403 "Resource not accessible by integration" on all three test PRs (#165, #166, #167) even though the agent correctly classified them as backport candidates.

Cause: GitHub gates label writes to a **PR** on the `pull-requests` permission, not `issues`, even though the REST URL is `/issues/{number}/labels`. The workflow had `pull-requests: read` and `issues: write`, which is enough to read PR metadata + post comments but not to add labels.

Fix: bump `pull-requests` to `write`. Matches what the sibling `backport_labels.yml` workflow already does.