### PR TITLE
test: README title rename (conflict-test fixture)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/6064/badge)](https://bestpractices.coreinfrastructure.org/projects/6064)
 
 <div align=center>
-<h1>Calico</h1>
+<h1>Calico Open Source</h1>
 <h2>
 <a href="https://projectcalico.docs.tigera.io/getting-started/kubernetes/quickstart">Quickstart</a> |
 <a href="https://projectcalico.docs.tigera.io">Docs</a> |


### PR DESCRIPTION
Test PR designed to produce a deterministic cherry-pick conflict against `tigera/calico-enterprise-test` master.

## What this PR does
Renames the README.md `<h1>Calico</h1>` line to `<h1>Calico Open Source</h1>`.

## Why
`tigera/calico-enterprise-test` master already has a conflicting rename to `<h1>Calico Enterprise</h1>` on the exact same line. When the merge-queue-bot tries to cherry-pick this PR's merge commit into EE master, git will hit a content conflict on `README.md`.

This is the fixture for **Phase 1** of the AI-resolver workflow demo. After merging this PR, the bot should attempt the cherry-pick, fail with a conflict, and the new conflict-resolver workflow should be exercised to resolve it via Claude.

## Verify locally (after merge)
```
cd calico-enterprise-test
git fetch upstream  # upstream = calico-oss-test
git checkout master
git pull origin master --ff-only
git cherry-pick --mainline=1 <merge-sha>
# Should produce: CONFLICT (content): Merge conflict in README.md
```