### PR TITLE
Council of Claudes: multi-agent PR code review workflow

### DIFF
--- a/.github/workflows/council_of_claudes.yml
+++ b/.github/workflows/council_of_claudes.yml
@@ -1,0 +1,52 @@
+# Council of Claudes — single-stage PR code review.
+#
+# On a pull request, fans out the PR's diff to persona-based review agents
+# hosted on the kagent cluster (agents.tigera.ai) and posts each persona's
+# feedback back to the PR as a distinct review.
+#
+# Single-stage (unlike the two-stage fork-safe model in cherry_pick_candidate.yml):
+# our demo PRs are same-repo branches, which receive secrets + a write-scoped
+# GITHUB_TOKEN directly. All logic lives in
+# .github/workflows/scripts/council_of_claudes.js.
+#
+# Each persona is gated on its own *_AGENT_URL / *_AGENT_TOKEN repo secrets;
+# personas whose secrets are unset are skipped, so the workflow is usable with
+# only one persona configured (e.g. Correctness first).
+
+name: Council of Claudes
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+concurrency:
+  # Coalesce rapid pushes to the same PR branch; cancel superseded runs.
+  group: council-of-claudes-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      CORRECTNESS_AGENT_URL: ${{ secrets.CORRECTNESS_AGENT_URL }}
+      CORRECTNESS_AGENT_TOKEN: ${{ secrets.CORRECTNESS_AGENT_TOKEN }}
+      MAINTAINABILITY_AGENT_URL: ${{ secrets.MAINTAINABILITY_AGENT_URL }}
+      MAINTAINABILITY_AGENT_TOKEN: ${{ secrets.MAINTAINABILITY_AGENT_TOKEN }}
+      SECURITY_AGENT_URL: ${{ secrets.SECURITY_AGENT_URL }}
+      SECURITY_AGENT_TOKEN: ${{ secrets.SECURITY_AGENT_TOKEN }}
+    steps:
+      # pull_request checks out the merge ref by default, so the script comes
+      # from the PR's own tree — letting us iterate on the workflow via its PR.
+      - name: Checkout workflow scripts
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Review pull request
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const fn = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/council_of_claudes.js`);
+            await fn({ github, context, core });

--- a/.github/workflows/scripts/council_of_claudes.js
+++ b/.github/workflows/scripts/council_of_claudes.js
@@ -178,19 +178,33 @@ module.exports = async ({ github, context, core }) => {
     return { persona: p, review };
   }));
 
-  // 4. Post one PR review per persona that responded.
+  // 4. Post one *sticky* PR review per persona. Each body carries a hidden
+  //    per-persona marker; if a prior review with that marker exists we update
+  //    it in place (so re-runs replace rather than accumulate), otherwise we
+  //    create a new one. We replace (not merge): each run reflects the current
+  //    diff. Staying in the reviews API also keeps the door open for inline
+  //    line-anchored comments later (a comments[] array on the review).
+  const existing = await github.paginate(github.rest.pulls.listReviews, { owner, repo, pull_number });
   let posted = 0;
   for (const res of results) {
     if (!res) continue;
-    const body = `### 🤖 Council of Claudes — ${res.persona.title}\n\n${res.review}`;
+    const marker = `<!-- council-of-claudes:${res.persona.key} -->`;
+    const body = `### 🤖 Council of Claudes — ${res.persona.title}\n\n${res.review}\n\n${marker}`;
+    // Most recent prior review carrying this persona's marker, if any.
+    const prior = existing.filter(r => (r.body || '').includes(marker)).pop();
     try {
-      await github.rest.pulls.createReview({
-        owner, repo, pull_number, commit_id: pr.head.sha, event: 'COMMENT', body,
-      });
+      if (prior) {
+        await github.rest.pulls.updateReview({ owner, repo, pull_number, review_id: prior.id, body });
+        core.info(`${res.persona.title}: review updated in place (#${prior.id})`);
+      } else {
+        await github.rest.pulls.createReview({
+          owner, repo, pull_number, commit_id: pr.head.sha, event: 'COMMENT', body,
+        });
+        core.info(`${res.persona.title}: review posted (new)`);
+      }
       posted++;
-      core.info(`${res.persona.title}: review posted`);
     } catch (e) {
-      core.warning(`${res.persona.title}: failed to post review (${safe(e.message)})`);
+      core.warning(`${res.persona.title}: failed to post/update review (${safe(e.message)})`);
     }
   }
   core.info(`Done: ${posted}/${active.length} persona review(s) posted to PR #${pull_number}`);

--- a/.github/workflows/scripts/council_of_claudes.js
+++ b/.github/workflows/scripts/council_of_claudes.js
@@ -7,10 +7,15 @@
 // (sourced from repo secrets). Any persona whose vars are unset is skipped
 // with a warning, so the workflow is usable with only one persona configured.
 //
-// Agent call contract (verified against tigera/agents-menagerie):
-//   POST <url>  with Bearer <token>, JSON-RPC 2.0 method "message/send".
-//   Input  -> params.message.parts[0].text
-//   Output <- result.artifacts[0].parts[0].text  (markdown)
+// Agent call contract (verified against tigera/agents-menagerie + live tests):
+//   POST <url> with Bearer <token>, JSON-RPC 2.0.
+//   The public endpoint enforces a ~30s cap on a synchronous response, but a
+//   full review generation takes longer, so we submit ASYNCHRONOUSLY:
+//     1. message/send with params.configuration.blocking=false
+//        -> returns immediately with result.id (a task id), state "submitted".
+//     2. poll tasks/get { id } every few seconds until status.state is
+//        terminal; on "completed", the review is result.artifacts[0].parts[0].text.
+//   Each individual call is fast, so none hits the 30s cap.
 
 const PERSONAS = [
   { key: 'correctness',     title: 'Correctness',             urlEnv: 'CORRECTNESS_AGENT_URL',     tokenEnv: 'CORRECTNESS_AGENT_TOKEN' },
@@ -21,6 +26,13 @@ const PERSONAS = [
 // Cap the diff we send to keep within model context. Large-PR handling is out
 // of scope for the hackathon; oversized diffs are truncated with a note.
 const MAX_DIFF_BYTES = 100 * 1024;
+
+// Async task polling parameters.
+const POLL_INTERVAL_MS = 5_000;
+const MAX_POLL_MS = 10 * 60 * 1000; // give a slow generation up to 10 minutes
+const RPC_TIMEOUT_MS = 30_000;      // each individual call is quick
+
+const sleep = ms => new Promise(res => setTimeout(res, ms));
 
 // Sanitize agent-controlled text before logging so it cannot inject
 // ::workflow-command:: strings into the Actions log (matches the guard in
@@ -35,47 +47,72 @@ function stripOuterFence(text) {
   return (m ? m[1] : t).trim();
 }
 
-// Call one persona agent. Returns its markdown review text, or null on failure.
-// Up to 3 attempts with 5s/10s backoff (mirrors cherry_pick_candidate.js).
-async function callAgent({ core, title, url, token, messageText, msgId }) {
-  const payload = {
-    jsonrpc: '2.0',
-    id: msgId,
-    method: 'message/send',
-    params: {
-      message: {
-        messageId: msgId,
-        role: 'user',
-        parts: [{ kind: 'text', text: messageText }],
-      },
-      configuration: { acceptedOutputModes: ['application/json', 'text/plain'] },
-    },
-  };
+// One JSON-RPC POST. Throws on non-2xx or network error.
+async function rpc(url, token, body) {
+  const r = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(RPC_TIMEOUT_MS),
+  });
+  if (!r.ok) throw new Error(`http ${r.status}`);
+  return r.json();
+}
 
+// Pull the agent's text out of a completed task: prefer the first artifact's
+// text part, fall back to the final status message.
+function extractText(task) {
+  const fromArtifacts = task?.artifacts?.[0]?.parts?.find(p => p.text)?.text;
+  if (fromArtifacts) return fromArtifacts;
+  return task?.status?.message?.parts?.find(p => p.text)?.text || '';
+}
+
+// Submit the review asynchronously and poll to completion. Returns the
+// persona's markdown review, or null on failure.
+async function reviewWithAgent({ core, title, url, token, messageText, msgId }) {
+  // 1. Submit non-blocking (up to 3 attempts with 5s/10s backoff).
+  let taskId = null;
   for (let attempt = 1; attempt <= 3; attempt++) {
     try {
-      const r = await fetch(url, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
+      const sub = await rpc(url, token, {
+        jsonrpc: '2.0', id: msgId, method: 'message/send',
+        params: {
+          message: { messageId: msgId, role: 'user', kind: 'message', parts: [{ kind: 'text', text: messageText }] },
+          configuration: { blocking: false, acceptedOutputModes: ['application/json', 'text/plain'] },
         },
-        body: JSON.stringify(payload),
-        signal: AbortSignal.timeout(120_000),
       });
-      if (r.ok) {
-        const response = await r.json();
-        const raw = response.result?.artifacts?.[0]?.parts?.[0]?.text
-          ?? response.result?.parts?.[0]?.text
-          ?? '';
-        return stripOuterFence(raw);
-      }
-      core.info(`  ${title}: attempt ${attempt} failed (http=${r.status})`);
+      taskId = sub.result?.id;
+      if (taskId) break;
+      core.info(`  ${title}: submit returned no task id (attempt ${attempt})`);
     } catch (e) {
-      core.info(`  ${title}: attempt ${attempt} failed (${e.message})`);
+      core.info(`  ${title}: submit attempt ${attempt} failed (${e.message})`);
     }
-    if (attempt < 3) await new Promise(res => setTimeout(res, attempt * 5000));
+    if (attempt < 3) await sleep(attempt * 5000);
   }
+  if (!taskId) return null;
+
+  // 2. Poll tasks/get until the task reaches a terminal state. Transient poll
+  //    errors are tolerated (keep polling until the overall deadline).
+  const start = Date.now();
+  while (Date.now() - start < MAX_POLL_MS) {
+    await sleep(POLL_INTERVAL_MS);
+    let task;
+    try {
+      const g = await rpc(url, token, { jsonrpc: '2.0', id: `${msgId}-get`, method: 'tasks/get', params: { id: taskId } });
+      task = g.result;
+    } catch (e) {
+      core.info(`  ${title}: poll error (${e.message}), will retry`);
+      continue;
+    }
+    const state = task?.status?.state;
+    if (state === 'completed') return stripOuterFence(extractText(task));
+    if (state === 'failed' || state === 'canceled' || state === 'rejected') {
+      core.warning(`${title}: task ${state}`);
+      return null;
+    }
+    // "submitted" / "working" -> keep polling
+  }
+  core.warning(`${title}: task did not complete within ${MAX_POLL_MS / 1000}s`);
   return null;
 }
 
@@ -123,9 +160,9 @@ module.exports = async ({ github, context, core }) => {
   core.info(`Reviewing PR #${pull_number} with ${active.length} persona(s): ${active.map(p => p.title).join(', ')}`);
   const results = await Promise.all(active.map(async p => {
     const msgId = `council-${p.key}-${pull_number}-${process.env.GITHUB_RUN_ID}`;
-    const review = await callAgent({ core, title: p.title, url: p.url, token: p.token, messageText, msgId });
+    const review = await reviewWithAgent({ core, title: p.title, url: p.url, token: p.token, messageText, msgId });
     if (!review) {
-      core.warning(`${p.title}: agent unreachable after 3 attempts, skipping`);
+      core.warning(`${p.title}: no review produced, skipping`);
       return null;
     }
     core.info(`${p.title}: received ${review.length} chars of feedback`);

--- a/.github/workflows/scripts/council_of_claudes.js
+++ b/.github/workflows/scripts/council_of_claudes.js
@@ -1,0 +1,151 @@
+// Council of Claudes — fan out a PR's diff to persona-based review agents on
+// the kagent cluster (agents.tigera.ai) and post each persona's feedback back
+// to the PR as a distinct review. Invoked from council_of_claudes.yml via
+// actions/github-script.
+//
+// Each persona is gated on its own *_AGENT_URL / *_AGENT_TOKEN env vars
+// (sourced from repo secrets). Any persona whose vars are unset is skipped
+// with a warning, so the workflow is usable with only one persona configured.
+//
+// Agent call contract (verified against tigera/agents-menagerie):
+//   POST <url>  with Bearer <token>, JSON-RPC 2.0 method "message/send".
+//   Input  -> params.message.parts[0].text
+//   Output <- result.artifacts[0].parts[0].text  (markdown)
+
+const PERSONAS = [
+  { key: 'correctness',     title: 'Correctness',             urlEnv: 'CORRECTNESS_AGENT_URL',     tokenEnv: 'CORRECTNESS_AGENT_TOKEN' },
+  { key: 'maintainability', title: 'Maintainability & Tests', urlEnv: 'MAINTAINABILITY_AGENT_URL', tokenEnv: 'MAINTAINABILITY_AGENT_TOKEN' },
+  { key: 'security',        title: 'Security',                urlEnv: 'SECURITY_AGENT_URL',        tokenEnv: 'SECURITY_AGENT_TOKEN' },
+];
+
+// Cap the diff we send to keep within model context. Large-PR handling is out
+// of scope for the hackathon; oversized diffs are truncated with a note.
+const MAX_DIFF_BYTES = 100 * 1024;
+
+// Sanitize agent-controlled text before logging so it cannot inject
+// ::workflow-command:: strings into the Actions log (matches the guard in
+// cherry_pick_candidate.js).
+const safe = s => String(s ?? '').replace(/::/g, ':​:');
+
+// Strip a single markdown fence that wraps the *entire* response, while
+// leaving any inner code/suggestion fences intact.
+function stripOuterFence(text) {
+  const t = (text || '').trim();
+  const m = t.match(/^```(?:markdown|md)?\s*\n([\s\S]*?)\n```$/);
+  return (m ? m[1] : t).trim();
+}
+
+// Call one persona agent. Returns its markdown review text, or null on failure.
+// Up to 3 attempts with 5s/10s backoff (mirrors cherry_pick_candidate.js).
+async function callAgent({ core, title, url, token, messageText, msgId }) {
+  const payload = {
+    jsonrpc: '2.0',
+    id: msgId,
+    method: 'message/send',
+    params: {
+      message: {
+        messageId: msgId,
+        role: 'user',
+        parts: [{ kind: 'text', text: messageText }],
+      },
+      configuration: { acceptedOutputModes: ['application/json', 'text/plain'] },
+    },
+  };
+
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const r = await fetch(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(120_000),
+      });
+      if (r.ok) {
+        const response = await r.json();
+        const raw = response.result?.artifacts?.[0]?.parts?.[0]?.text
+          ?? response.result?.parts?.[0]?.text
+          ?? '';
+        return stripOuterFence(raw);
+      }
+      core.info(`  ${title}: attempt ${attempt} failed (http=${r.status})`);
+    } catch (e) {
+      core.info(`  ${title}: attempt ${attempt} failed (${e.message})`);
+    }
+    if (attempt < 3) await new Promise(res => setTimeout(res, attempt * 5000));
+  }
+  return null;
+}
+
+module.exports = async ({ github, context, core }) => {
+  const { owner, repo } = context.repo;
+  const pr = context.payload.pull_request;
+  if (!pr) {
+    core.warning('No pull_request in payload, skipping');
+    return;
+  }
+  const pull_number = pr.number;
+
+  // 1. Determine which personas are actually configured.
+  const active = PERSONAS
+    .map(p => ({ ...p, url: process.env[p.urlEnv], token: process.env[p.tokenEnv] }))
+    .filter(p => {
+      if (p.url && p.token) return true;
+      core.warning(`${p.title}: ${p.urlEnv}/${p.tokenEnv} not set, skipping persona`);
+      return false;
+    });
+  if (active.length === 0) {
+    core.warning('No persona agents configured, nothing to do');
+    return;
+  }
+
+  // 2. Fetch the unified diff inline (size-guarded).
+  const diffResp = await github.rest.pulls.get({
+    owner, repo, pull_number, mediaType: { format: 'diff' },
+  });
+  let diff = diffResp.data;
+  let truncated = false;
+  if (Buffer.byteLength(diff, 'utf8') > MAX_DIFF_BYTES) {
+    diff = diff.slice(0, MAX_DIFF_BYTES);
+    truncated = true;
+    core.warning(`diff exceeds ${MAX_DIFF_BYTES} bytes, truncated (large-PR handling out of scope)`);
+  }
+
+  const messageText =
+    `PR #${pull_number}: ${pr.title}\n\n` +
+    `Description:\n${pr.body || '(none)'}\n\n` +
+    (truncated ? '(NOTE: the diff below was truncated for size.)\n\n' : '') +
+    `Unified diff:\n${diff}`;
+
+  // 3. Fan out to all configured personas in parallel; isolate failures.
+  core.info(`Reviewing PR #${pull_number} with ${active.length} persona(s): ${active.map(p => p.title).join(', ')}`);
+  const results = await Promise.all(active.map(async p => {
+    const msgId = `council-${p.key}-${pull_number}-${process.env.GITHUB_RUN_ID}`;
+    const review = await callAgent({ core, title: p.title, url: p.url, token: p.token, messageText, msgId });
+    if (!review) {
+      core.warning(`${p.title}: agent unreachable after 3 attempts, skipping`);
+      return null;
+    }
+    core.info(`${p.title}: received ${review.length} chars of feedback`);
+    return { persona: p, review };
+  }));
+
+  // 4. Post one PR review per persona that responded.
+  let posted = 0;
+  for (const res of results) {
+    if (!res) continue;
+    const body = `### 🤖 Council of Claudes — ${res.persona.title}\n\n${res.review}`;
+    try {
+      await github.rest.pulls.createReview({
+        owner, repo, pull_number, commit_id: pr.head.sha, event: 'COMMENT', body,
+      });
+      posted++;
+      core.info(`${res.persona.title}: review posted`);
+    } catch (e) {
+      core.warning(`${res.persona.title}: failed to post review (${safe(e.message)})`);
+    }
+  }
+  core.info(`Done: ${posted}/${active.length} persona review(s) posted to PR #${pull_number}`);
+};

--- a/.github/workflows/scripts/council_of_claudes.js
+++ b/.github/workflows/scripts/council_of_claudes.js
@@ -47,7 +47,9 @@ function stripOuterFence(text) {
   return (m ? m[1] : t).trim();
 }
 
-// One JSON-RPC POST. Throws on non-2xx or network error.
+// One JSON-RPC POST. Throws on non-2xx, network error, or a JSON-RPC error
+// payload (a 200 response carrying an `error` field — otherwise it would be
+// silently mistaken for a missing result).
 async function rpc(url, token, body) {
   const r = await fetch(url, {
     method: 'POST',
@@ -56,7 +58,11 @@ async function rpc(url, token, body) {
     signal: AbortSignal.timeout(RPC_TIMEOUT_MS),
   });
   if (!r.ok) throw new Error(`http ${r.status}`);
-  return r.json();
+  const json = await r.json();
+  if (json.error) {
+    throw new Error(`json-rpc error ${json.error.code ?? '?'}: ${json.error.message ?? 'unknown'}`);
+  }
+  return json;
 }
 
 // Pull the agent's text out of a completed task: prefer the first artifact's
@@ -145,7 +151,10 @@ module.exports = async ({ github, context, core }) => {
   let diff = diffResp.data;
   let truncated = false;
   if (Buffer.byteLength(diff, 'utf8') > MAX_DIFF_BYTES) {
-    diff = diff.slice(0, MAX_DIFF_BYTES);
+    // Slice on a byte boundary; TextDecoder with stream:true drops a trailing
+    // partial multi-byte sequence rather than emitting a replacement char.
+    const buf = Buffer.from(diff, 'utf8').subarray(0, MAX_DIFF_BYTES);
+    diff = new TextDecoder('utf-8').decode(buf, { stream: true });
     truncated = true;
     core.warning(`diff exceeds ${MAX_DIFF_BYTES} bytes, truncated (large-PR handling out of scope)`);
   }

--- a/.github/workflows/scripts/council_of_claudes.js
+++ b/.github/workflows/scripts/council_of_claudes.js
@@ -91,7 +91,7 @@ async function reviewWithAgent({ core, title, url, token, messageText, msgId }) 
       if (taskId) break;
       core.info(`  ${title}: submit returned no task id (attempt ${attempt})`);
     } catch (e) {
-      core.info(`  ${title}: submit attempt ${attempt} failed (${e.message})`);
+      core.info(`  ${title}: submit attempt ${attempt} failed (${safe(e.message)})`);
     }
     if (attempt < 3) await sleep(attempt * 5000);
   }
@@ -107,7 +107,7 @@ async function reviewWithAgent({ core, title, url, token, messageText, msgId }) 
       const g = await rpc(url, token, { jsonrpc: '2.0', id: `${msgId}-get`, method: 'tasks/get', params: { id: taskId } });
       task = g.result;
     } catch (e) {
-      core.info(`  ${title}: poll error (${e.message}), will retry`);
+      core.info(`  ${title}: poll error (${safe(e.message)}), will retry`);
       continue;
     }
     const state = task?.status?.state;

--- a/.github/workflows/scripts/personas/correctness.md
+++ b/.github/workflows/scripts/personas/correctness.md
@@ -1,0 +1,43 @@
+# Correctness Reviewer — Council of Claudes
+
+Paste this as the `systemMessage` when creating the **Correctness** agent in the
+kagent portal (https://agents.tigera.ai). Model: `gpt-5`.
+
+---
+
+You are a senior software engineer performing the **Correctness** lens of a code review for a
+Project Calico pull request. Calico is a large Go (with some Python) Kubernetes networking and
+network-policy project.
+
+## Input
+You receive the pull request's title, body, and full unified diff.
+
+## Your lens — review ONLY for correctness
+Focus exclusively on whether the change is correct and complete:
+- **Does it do what it's supposed to?** Logic bugs, wrong conditions, off-by-one, inverted
+  checks, wrong operators, copy-paste mistakes.
+- **Meets its intent/spec** as described in the PR title and body.
+- **Completeness:** unhandled errors, ignored return values, missing edge/corner cases,
+  nil/empty handling, unexpected input or misconfiguration.
+- **Resource handling:** leaks, unclosed resources, missing `defer` cleanup, goroutine leaks.
+- **Concurrency:** data races, unsynchronized shared state, deadlocks, misuse of
+  channels/locks/contexts.
+- **Performance & scale:** accidental O(n²), unbounded growth, expensive work in hot paths —
+  only where it is a genuine concern for this change.
+- **API usage:** does the code handle all corner cases of the APIs it calls?
+
+Do **not** comment on style, naming, test coverage, documentation, or security unless it
+directly causes a correctness bug — those belong to other reviewers.
+
+## Output format
+Respond in concise markdown:
+1. A single-line **verdict** (e.g. "No correctness issues found" or "2 potential correctness issues").
+2. A bulleted list of findings. For each: name the **file** and approximate **hunk/line**,
+   describe the **issue**, and suggest a **fix**.
+
+## Rules
+- Raise only substantive issues. Do not rubber-stamp and do not pad with trivia.
+- If you genuinely find nothing material, say so briefly.
+- You are advisory only — never instruct to approve or block.
+- Base findings on the diff provided; if you lack surrounding context, say what you would want
+  to verify rather than guessing.

--- a/.github/workflows/scripts/personas/maintainability-tests.md
+++ b/.github/workflows/scripts/personas/maintainability-tests.md
@@ -1,0 +1,43 @@
+# Maintainability & Tests Reviewer — Council of Claudes
+
+Paste this as the `systemMessage` when creating the **Maintainability & Tests** agent in the
+kagent portal (https://agents.tigera.ai). Model: `gpt-5`.
+
+---
+
+You are a senior software engineer performing the **Maintainability & Tests** lens of a code
+review for a Project Calico pull request. Calico is a large Go (with some Python) Kubernetes
+networking and network-policy project. Most of the cost of code is paid after it is written, so
+optimise for the engineer who maintains this in a year or two.
+
+## Input
+You receive the pull request's title, body, and full unified diff.
+
+## Your lens — review ONLY for maintainability and testing
+- **Simplicity:** is it as simple as possible while meeting its requirements? Flag
+  over-engineering, needless complexity, dead code, and duplication.
+- **Regression tests:** does the change add or update tests so a future break is detected? Are
+  new code paths and edge cases covered? Are the tests meaningful (not just coverage padding)?
+- **Documentation & comment budget:** is there enough context to understand the code and *why*
+  it was written later? Comments should be spent wisely — not every line, but a clear
+  "here be dragons" note above genuinely subtle code.
+- **Maintenance burden:** will this cause future pain? Tight coupling, leaky abstractions,
+  unclear ownership, fragile assumptions.
+- **Readability & idioms:** clear names; consistent with the surrounding code; idiomatic Go and
+  in line with project norms.
+
+Do **not** comment on correctness bugs, runtime behaviour, or security except where it directly
+affects maintainability — those belong to other reviewers.
+
+## Output format
+Respond in concise markdown:
+1. A single-line **verdict** (e.g. "Well-tested and maintainable" or "Missing test coverage; 2 concerns").
+2. A bulleted list of findings. For each: name the **file** and approximate **hunk/line**,
+   describe the **issue**, and suggest a **fix**.
+
+## Rules
+- Raise only substantive issues. Do not rubber-stamp and do not pad with trivia.
+- If you genuinely find nothing material, say so briefly.
+- You are advisory only — never instruct to approve or block.
+- Base findings on the diff provided; if you lack surrounding context, say what you would want
+  to verify rather than guessing.

--- a/.github/workflows/scripts/personas/security.md
+++ b/.github/workflows/scripts/personas/security.md
@@ -1,0 +1,42 @@
+# Security Reviewer — Council of Claudes
+
+Paste this as the `systemMessage` when creating the **Security** agent in the
+kagent portal (https://agents.tigera.ai). Model: `gpt-5`.
+
+---
+
+You are a senior security-minded engineer performing the **Security** lens of a code review for
+a Project Calico pull request. Calico is a large Go (with some Python) Kubernetes networking and
+network-policy project, so isolation and policy enforcement are security-critical.
+
+## Input
+You receive the pull request's title, body, and full unified diff.
+
+## Your lens — review ONLY for security
+- **Input/parameter validation:** is untrusted input validated and sanitised before use?
+- **Data in transit:** is sensitive data encrypted where required (e.g. TLS)? Any plaintext
+  credentials or tokens?
+- **Injection-safe access:** SQL/command/template injection, unsafe deserialization, path
+  traversal, unsafe use of `exec`.
+- **Secrets handling:** hardcoded secrets, secrets written to logs, tokens or keys leaking
+  through error messages or output.
+- **Authorization & authentication:** are permission checks correct? Any privilege-escalation
+  risk? For a network-policy codebase: does the change weaken isolation, default-deny posture,
+  or policy enforcement?
+- **Unsafe defaults / overly broad permissions:** RBAC, capabilities, file modes, network scope.
+
+Do **not** comment on style, naming, test coverage, or general correctness unless it has a
+direct security impact — those belong to other reviewers.
+
+## Output format
+Respond in concise markdown:
+1. A single-line **verdict** (e.g. "No security concerns found" or "1 potential security issue").
+2. A bulleted list of findings. For each: name the **file** and approximate **hunk/line**,
+   describe the **risk**, and suggest a **mitigation**.
+
+## Rules
+- Raise only substantive issues. Do not rubber-stamp and do not pad with trivia.
+- If you genuinely find nothing material, say so briefly.
+- You are advisory only — never instruct to approve or block.
+- Base findings on the diff provided; if you lack surrounding context, say what you would want
+  to verify rather than guessing.


### PR DESCRIPTION
## What

Hackathon project: a single-stage `pull_request` GitHub Action that fans out a PR's unified diff to **persona-based LLM review agents** on the kagent cluster (`agents.tigera.ai`) and posts each persona's feedback back as a distinct PR review — a "council" of focused reviewers replacing one monolithic review pass.

## How it works

1. `pull_request` (opened/reopened/synchronize) triggers `council_of_claudes.yml`.
2. `scripts/council_of_claudes.js` fetches the unified diff inline, fans out **in parallel** to each configured persona agent (JSON-RPC `message/send`, Bearer auth — same proven pattern as `cherry_pick_candidate.js`), and posts **one PR review per persona**.
3. Each persona is gated on its own repo secrets; unset personas are skipped, so this runs with as few as **one** persona configured.

## Personas

Mapped to our [Code review guidelines](https://tigera.atlassian.net/wiki/spaces/ENG/pages/2367979521/Code+review). `systemMessage` prompts live in `scripts/personas/`:
- **Correctness** — bugs, completeness, error/edge handling, concurrency, perf/scale
- **Maintainability & Tests** — simplicity, test coverage, docs, idioms
- **Security** — input validation, secrets, authz, policy-isolation impact

## Required secrets (per persona)

`CORRECTNESS_AGENT_URL` / `CORRECTNESS_AGENT_TOKEN`,
`MAINTAINABILITY_AGENT_URL` / `MAINTAINABILITY_AGENT_TOKEN`,
`SECURITY_AGENT_URL` / `SECURITY_AGENT_TOKEN`.
URL = the agent's `https://agents.tigera.ai/pub/{slug}` endpoint; token = its published bearer token. **The workflow is a safe no-op until at least one persona's secrets are set.**

## Scope notes

Single-stage (same-repo PRs only — not the two-stage fork-safe model); no inline line-anchoring; diff capped at ~100 KB. These are intentional hackathon scope cuts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)