### PR TITLE
docs: refresh contributor/security framing and add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable user-facing changes to Project Calico are recorded in this file.
+This document complements the per-release notes published on
+https://docs.tigera.io/calico/latest/release-notes/.
+
+## Unreleased
+
+- Updated `CONTRIBUTING.md` first-paragraph framing to make the community
+  contribution path more prominent.
+- Updated `SECURITY.md` "Supported Versions" wording to align with the
+  current three-minor-version rolling support window.
+- Introduced this `CHANGELOG.md` file as a single rolling log of
+  user-facing changes between formal releases.
+
+## How to update
+
+When opening a PR with a user-facing change, please add a bullet under
+`## Unreleased` describing the change in one sentence. At release time
+the maintainers move the `Unreleased` section under a new dated heading
+matching the release tag.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,6 @@
-# Contributing to the Calico Codebase
+# Contributing to Project Calico
 
-Thanks for considering contributing to Calico! This document outlines the canonical procedure for contributing new features
-and bugfixes to Calico. Following these steps will help ensure that your contribution gets merged quickly and
-efficiently.
+Welcome! Project Calico is a community-driven open source networking project under the CNCF, with a wide contributor base across many organisations. This guide explains how to contribute code, file issues, and propose features. Please read it through carefully before submitting your first pull request -- a small amount of upfront alignment makes review much faster for everyone.
 
 ## Overview
 
@@ -93,3 +91,8 @@ on GitHub.
 
 [fork]: https://help.github.com/articles/fork-a-repo/
 [pulls]: https://help.github.com/articles/creating-a-pull-request/
+
+## Code of Conduct
+
+This project adheres to the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+By participating, you are expected to uphold this code. Please report unacceptable behaviour to the project maintainers via the channels listed in the CNCF policy.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,11 @@
 
 ## Supported Versions
 
-The Tigera team generally support the most recent two minor versions
-of Project Calico on a rolling basis.  Support for older versions is on a 
-case-by-case basis.  For example, at the time of writing, 
-Calico v3.26.x and v3.25.x are supported.  When v3.27.0 is released,
-automatic support for v3.25.x is dropped.
+The Project Calico community supports the most recent three minor
+versions on a rolling basis. Older versions receive security-only
+patches at the maintainers' discretion. The current support window is
+documented in the release notes for each minor release on
+https://docs.tigera.io/calico/latest/release-notes/.
 
 ## Reporting a Vulnerability
 
@@ -20,6 +20,10 @@ request because those are immediately public. Instead:
 
 Please include as much information as possible, including the
 affected version(s) and steps to reproduce.
+
+## Bug Bounty
+
+Project Calico does not currently operate a bug bounty programme. Researchers who would like to be acknowledged for valid reports can request a public mention in the release notes for the version that ships the fix.
 
 ## Third Party Vulnerabilities
 


### PR DESCRIPTION
Updates community-facing documentation:

- **CONTRIBUTING.md** -- rewrite the lede to lean into the community/CNCF framing; add a Code of Conduct section at the end.
- **SECURITY.md** -- update the *Supported Versions* paragraph to a three-minor-version rolling window; add a *Bug Bounty* section.
- **CHANGELOG.md** -- introduce a top-level changelog covering user-facing changes between formal releases.

## Cherry-pick conflict fixture (Phase 1 demo)

This PR is *also* the deterministic multi-file conflict fixture for the **AI Cherry-Pick Conflict Resolver** workflow in `skoryk-oleksandr/calico-enterprise`. On the EE side, `CONTRIBUTING.md` and `SECURITY.md` already carry enterprise-specific text on the same lines this PR rewrites, so cherry-picking the merge commit into EE master will produce conflicts in two files. The new `CHANGELOG.md` adds a fresh file with no EE counterpart and should apply cleanly, giving the resolved cherry-pick real diff content beyond the conflict resolutions.

When this PR is merged, dispatch the workflow with this PR's merge SHA and watch Claude resolve the conflicts via the `pick-oss-pr` skill.