### PR TITLE
Allow server-side apply to create tiered policies

### DIFF
--- a/apiserver/pkg/registry/projectcalico/globalpolicy/storage.go
+++ b/apiserver/pkg/registry/projectcalico/globalpolicy/storage.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/uuid"
 	calico "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -132,26 +133,39 @@ func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 	updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions,
 ) (runtime.Object, bool, error) {
 	oldObj, err := r.Store.Get(ctx, name, &metav1.GetOptions{})
-	if err != nil {
-		return nil, false, err
-	}
-	oldTier := names.TierOrDefault(oldObj.(*calico.GlobalNetworkPolicy).Spec.Tier)
-	err = r.authorizer.AuthorizeTierOperation(ctx, name, oldTier)
-	if err != nil {
-		return nil, false, err
-	}
+	switch {
+	case err == nil:
+		oldTier := names.TierOrDefault(oldObj.(*calico.GlobalNetworkPolicy).Spec.Tier)
+		if err := r.authorizer.AuthorizeTierOperation(ctx, name, oldTier); err != nil {
+			return nil, false, err
+		}
 
-	// Also authorize the new tier, in case the update changes the policy's tier.
-	newObj, err := objInfo.UpdatedObject(ctx, oldObj)
-	if err != nil {
-		return nil, false, err
-	}
-	newTier := names.TierOrDefault(newObj.(*calico.GlobalNetworkPolicy).Spec.Tier)
-	if newTier != oldTier {
-		err = r.authorizer.AuthorizeTierOperation(ctx, name, newTier)
+		// Also authorize the new tier, in case the update changes the policy's tier.
+		newObj, err := objInfo.UpdatedObject(ctx, oldObj)
 		if err != nil {
 			return nil, false, err
 		}
+		newTier := names.TierOrDefault(newObj.(*calico.GlobalNetworkPolicy).Spec.Tier)
+		if newTier != oldTier {
+			if err := r.authorizer.AuthorizeTierOperation(ctx, name, newTier); err != nil {
+				return nil, false, err
+			}
+		}
+	case k8serrors.IsNotFound(err) && forceAllowCreate:
+		// A server-side apply of a policy that doesn't exist yet reaches Update
+		// with forceAllowCreate set rather than going through Create. There's no
+		// existing object to authorize against, so authorize the incoming object's
+		// tier and let the store create it.
+		newObj, err := objInfo.UpdatedObject(ctx, &calico.GlobalNetworkPolicy{})
+		if err != nil {
+			return nil, false, err
+		}
+		newTier := names.TierOrDefault(newObj.(*calico.GlobalNetworkPolicy).Spec.Tier)
+		if err := r.authorizer.AuthorizeTierOperation(ctx, name, newTier); err != nil {
+			return nil, false, err
+		}
+	default:
+		return nil, false, err
 	}
 
 	return r.Store.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)

--- a/apiserver/pkg/registry/projectcalico/networkpolicy/storage.go
+++ b/apiserver/pkg/registry/projectcalico/networkpolicy/storage.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/uuid"
 	calico "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -128,26 +129,39 @@ func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 	updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions,
 ) (runtime.Object, bool, error) {
 	oldObj, err := r.Store.Get(ctx, name, &metav1.GetOptions{})
-	if err != nil {
-		return nil, false, err
-	}
-	oldTier := names.TierOrDefault(oldObj.(*calico.NetworkPolicy).Spec.Tier)
-	err = r.authorizer.AuthorizeTierOperation(ctx, name, oldTier)
-	if err != nil {
-		return nil, false, err
-	}
+	switch {
+	case err == nil:
+		oldTier := names.TierOrDefault(oldObj.(*calico.NetworkPolicy).Spec.Tier)
+		if err := r.authorizer.AuthorizeTierOperation(ctx, name, oldTier); err != nil {
+			return nil, false, err
+		}
 
-	// Also authorize the new tier, in case the update changes the policy's tier.
-	newObj, err := objInfo.UpdatedObject(ctx, oldObj)
-	if err != nil {
-		return nil, false, err
-	}
-	newTier := names.TierOrDefault(newObj.(*calico.NetworkPolicy).Spec.Tier)
-	if newTier != oldTier {
-		err = r.authorizer.AuthorizeTierOperation(ctx, name, newTier)
+		// Also authorize the new tier, in case the update changes the policy's tier.
+		newObj, err := objInfo.UpdatedObject(ctx, oldObj)
 		if err != nil {
 			return nil, false, err
 		}
+		newTier := names.TierOrDefault(newObj.(*calico.NetworkPolicy).Spec.Tier)
+		if newTier != oldTier {
+			if err := r.authorizer.AuthorizeTierOperation(ctx, name, newTier); err != nil {
+				return nil, false, err
+			}
+		}
+	case k8serrors.IsNotFound(err) && forceAllowCreate:
+		// A server-side apply of a policy that doesn't exist yet reaches Update
+		// with forceAllowCreate set rather than going through Create. There's no
+		// existing object to authorize against, so authorize the incoming object's
+		// tier and let the store create it.
+		newObj, err := objInfo.UpdatedObject(ctx, &calico.NetworkPolicy{})
+		if err != nil {
+			return nil, false, err
+		}
+		newTier := names.TierOrDefault(newObj.(*calico.NetworkPolicy).Spec.Tier)
+		if err := r.authorizer.AuthorizeTierOperation(ctx, name, newTier); err != nil {
+			return nil, false, err
+		}
+	default:
+		return nil, false, err
 	}
 
 	return r.Store.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)

--- a/apiserver/pkg/registry/projectcalico/stagedglobalnetworkpolicy/storage.go
+++ b/apiserver/pkg/registry/projectcalico/stagedglobalnetworkpolicy/storage.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/uuid"
 	calico "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -132,26 +133,39 @@ func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 	updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions,
 ) (runtime.Object, bool, error) {
 	oldObj, err := r.Store.Get(ctx, name, &metav1.GetOptions{})
-	if err != nil {
-		return nil, false, err
-	}
-	oldTier := names.TierOrDefault(oldObj.(*calico.StagedGlobalNetworkPolicy).Spec.Tier)
-	err = r.authorizer.AuthorizeTierOperation(ctx, name, oldTier)
-	if err != nil {
-		return nil, false, err
-	}
+	switch {
+	case err == nil:
+		oldTier := names.TierOrDefault(oldObj.(*calico.StagedGlobalNetworkPolicy).Spec.Tier)
+		if err := r.authorizer.AuthorizeTierOperation(ctx, name, oldTier); err != nil {
+			return nil, false, err
+		}
 
-	// Also authorize the new tier, in case the update changes the policy's tier.
-	newObj, err := objInfo.UpdatedObject(ctx, oldObj)
-	if err != nil {
-		return nil, false, err
-	}
-	newTier := names.TierOrDefault(newObj.(*calico.StagedGlobalNetworkPolicy).Spec.Tier)
-	if newTier != oldTier {
-		err = r.authorizer.AuthorizeTierOperation(ctx, name, newTier)
+		// Also authorize the new tier, in case the update changes the policy's tier.
+		newObj, err := objInfo.UpdatedObject(ctx, oldObj)
 		if err != nil {
 			return nil, false, err
 		}
+		newTier := names.TierOrDefault(newObj.(*calico.StagedGlobalNetworkPolicy).Spec.Tier)
+		if newTier != oldTier {
+			if err := r.authorizer.AuthorizeTierOperation(ctx, name, newTier); err != nil {
+				return nil, false, err
+			}
+		}
+	case k8serrors.IsNotFound(err) && forceAllowCreate:
+		// A server-side apply of a policy that doesn't exist yet reaches Update
+		// with forceAllowCreate set rather than going through Create. There's no
+		// existing object to authorize against, so authorize the incoming object's
+		// tier and let the store create it.
+		newObj, err := objInfo.UpdatedObject(ctx, &calico.StagedGlobalNetworkPolicy{})
+		if err != nil {
+			return nil, false, err
+		}
+		newTier := names.TierOrDefault(newObj.(*calico.StagedGlobalNetworkPolicy).Spec.Tier)
+		if err := r.authorizer.AuthorizeTierOperation(ctx, name, newTier); err != nil {
+			return nil, false, err
+		}
+	default:
+		return nil, false, err
 	}
 
 	return r.Store.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)

--- a/apiserver/pkg/registry/projectcalico/stagednetworkpolicy/storage.go
+++ b/apiserver/pkg/registry/projectcalico/stagednetworkpolicy/storage.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/uuid"
 	calico "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -128,26 +129,39 @@ func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 	updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions,
 ) (runtime.Object, bool, error) {
 	oldObj, err := r.Store.Get(ctx, name, &metav1.GetOptions{})
-	if err != nil {
-		return nil, false, err
-	}
-	oldTier := names.TierOrDefault(oldObj.(*calico.StagedNetworkPolicy).Spec.Tier)
-	err = r.authorizer.AuthorizeTierOperation(ctx, name, oldTier)
-	if err != nil {
-		return nil, false, err
-	}
+	switch {
+	case err == nil:
+		oldTier := names.TierOrDefault(oldObj.(*calico.StagedNetworkPolicy).Spec.Tier)
+		if err := r.authorizer.AuthorizeTierOperation(ctx, name, oldTier); err != nil {
+			return nil, false, err
+		}
 
-	// Also authorize the new tier, in case the update changes the policy's tier.
-	newObj, err := objInfo.UpdatedObject(ctx, oldObj)
-	if err != nil {
-		return nil, false, err
-	}
-	newTier := names.TierOrDefault(newObj.(*calico.StagedNetworkPolicy).Spec.Tier)
-	if newTier != oldTier {
-		err = r.authorizer.AuthorizeTierOperation(ctx, name, newTier)
+		// Also authorize the new tier, in case the update changes the policy's tier.
+		newObj, err := objInfo.UpdatedObject(ctx, oldObj)
 		if err != nil {
 			return nil, false, err
 		}
+		newTier := names.TierOrDefault(newObj.(*calico.StagedNetworkPolicy).Spec.Tier)
+		if newTier != oldTier {
+			if err := r.authorizer.AuthorizeTierOperation(ctx, name, newTier); err != nil {
+				return nil, false, err
+			}
+		}
+	case k8serrors.IsNotFound(err) && forceAllowCreate:
+		// A server-side apply of a policy that doesn't exist yet reaches Update
+		// with forceAllowCreate set rather than going through Create. There's no
+		// existing object to authorize against, so authorize the incoming object's
+		// tier and let the store create it.
+		newObj, err := objInfo.UpdatedObject(ctx, &calico.StagedNetworkPolicy{})
+		if err != nil {
+			return nil, false, err
+		}
+		newTier := names.TierOrDefault(newObj.(*calico.StagedNetworkPolicy).Spec.Tier)
+		if err := r.authorizer.AuthorizeTierOperation(ctx, name, newTier); err != nil {
+			return nil, false, err
+		}
+	default:
+		return nil, false, err
 	}
 
 	return r.Store.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)

--- a/apiserver/test/integration/clientset_test.go
+++ b/apiserver/test/integration/clientset_test.go
@@ -17,6 +17,7 @@ package integration
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -34,6 +35,7 @@ import (
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
@@ -2509,4 +2511,113 @@ func testPolicyWatch(client calicoclient.Interface) error {
 	}
 
 	return nil
+}
+
+// TestServerSideApplyCreate locks in the fix for
+// https://github.com/projectcalico/calico/issues/12841. A server-side apply of a
+// tiered policy that doesn't exist yet reaches the apiserver as an update with
+// forceAllowCreate set, not as a Create. The tier RBAC check must not turn that
+// into a NotFound; the policy should be created.
+func TestServerSideApplyCreate(t *testing.T) {
+	client, shutdownServer := getFreshAPIServerAndClient(t, func() runtime.Object {
+		return &v3.GlobalNetworkPolicy{}
+	})
+	defer shutdownServer()
+
+	ctx := context.Background()
+	pc := client.ProjectcalicoV3()
+	const fieldManager = "ssa-test"
+
+	// applyCreate marshals obj and applies it, then runs getAfter to confirm the
+	// server created it. patch and getAfter close over the typed client for the
+	// resource under test, since each has its own concrete return type.
+	applyCreate := func(t *testing.T, obj runtime.Object, name string, patch func(data []byte) error, getAfter func() error) {
+		t.Helper()
+		data, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("failed to marshal %s: %v", name, err)
+		}
+		if err := patch(data); err != nil {
+			t.Fatalf("server-side apply create of %s failed: %v", name, err)
+		}
+		if err := getAfter(); err != nil {
+			t.Fatalf("%s was not created by server-side apply: %v", name, err)
+		}
+	}
+
+	t.Run("GlobalNetworkPolicy", func(t *testing.T) {
+		c := pc.GlobalNetworkPolicies()
+		obj := &v3.GlobalNetworkPolicy{
+			TypeMeta:   metav1.TypeMeta{APIVersion: v3.GroupVersionCurrent, Kind: v3.KindGlobalNetworkPolicy},
+			ObjectMeta: metav1.ObjectMeta{Name: "gnp-ssa"},
+			Spec:       v3.GlobalNetworkPolicySpec{Selector: "all()"},
+		}
+		applyCreate(t, obj, obj.Name,
+			func(data []byte) error {
+				_, err := c.Patch(ctx, obj.Name, types.ApplyPatchType, data, metav1.PatchOptions{FieldManager: fieldManager})
+				return err
+			},
+			func() error {
+				_, err := c.Get(ctx, obj.Name, metav1.GetOptions{})
+				return err
+			},
+		)
+	})
+
+	t.Run("NetworkPolicy", func(t *testing.T) {
+		c := pc.NetworkPolicies("default")
+		obj := &v3.NetworkPolicy{
+			TypeMeta:   metav1.TypeMeta{APIVersion: v3.GroupVersionCurrent, Kind: v3.KindNetworkPolicy},
+			ObjectMeta: metav1.ObjectMeta{Name: "np-ssa", Namespace: "default"},
+			Spec:       v3.NetworkPolicySpec{Selector: "all()"},
+		}
+		applyCreate(t, obj, obj.Name,
+			func(data []byte) error {
+				_, err := c.Patch(ctx, obj.Name, types.ApplyPatchType, data, metav1.PatchOptions{FieldManager: fieldManager})
+				return err
+			},
+			func() error {
+				_, err := c.Get(ctx, obj.Name, metav1.GetOptions{})
+				return err
+			},
+		)
+	})
+
+	t.Run("StagedGlobalNetworkPolicy", func(t *testing.T) {
+		c := pc.StagedGlobalNetworkPolicies()
+		obj := &v3.StagedGlobalNetworkPolicy{
+			TypeMeta:   metav1.TypeMeta{APIVersion: v3.GroupVersionCurrent, Kind: v3.KindStagedGlobalNetworkPolicy},
+			ObjectMeta: metav1.ObjectMeta{Name: "sgnp-ssa"},
+			Spec:       v3.StagedGlobalNetworkPolicySpec{StagedAction: "Set", Selector: "all()"},
+		}
+		applyCreate(t, obj, obj.Name,
+			func(data []byte) error {
+				_, err := c.Patch(ctx, obj.Name, types.ApplyPatchType, data, metav1.PatchOptions{FieldManager: fieldManager})
+				return err
+			},
+			func() error {
+				_, err := c.Get(ctx, obj.Name, metav1.GetOptions{})
+				return err
+			},
+		)
+	})
+
+	t.Run("StagedNetworkPolicy", func(t *testing.T) {
+		c := pc.StagedNetworkPolicies("default")
+		obj := &v3.StagedNetworkPolicy{
+			TypeMeta:   metav1.TypeMeta{APIVersion: v3.GroupVersionCurrent, Kind: v3.KindStagedNetworkPolicy},
+			ObjectMeta: metav1.ObjectMeta{Name: "snp-ssa", Namespace: "default"},
+			Spec:       v3.StagedNetworkPolicySpec{StagedAction: "Set", Selector: "all()"},
+		}
+		applyCreate(t, obj, obj.Name,
+			func(data []byte) error {
+				_, err := c.Patch(ctx, obj.Name, types.ApplyPatchType, data, metav1.PatchOptions{FieldManager: fieldManager})
+				return err
+			},
+			func() error {
+				_, err := c.Get(ctx, obj.Name, metav1.GetOptions{})
+				return err
+			},
+		)
+	})
 }


### PR DESCRIPTION
Recreated mirror of [projectcalico/calico#12905](https://github.com/projectcalico/calico/pull/12905) for the AI Cherry-Pick Conflict Resolver demo. Same 5-file diff the OSS PR landed.

When cherry-picked into `skoryk-oleksandr/calico-enterprise`, this should hit four canonical `projectcalico/api` -> `tigera/api` import-rewrite conflicts (one per `storage.go`). The `clientset_test.go` file is aligned on both repos' baselines and should apply cleanly.

## Original PR summary

Enables server-side apply for tiered policy types by adding the apiserver registry plumbing. See [projectcalico/calico#12905](https://github.com/projectcalico/calico/pull/12905) for the full context.