### PR TITLE
[sample #10997] BPF: Allows users to set DSCP on traffic toward hosts/hostendpoints

### DIFF
--- a/felix/bpf-gpl/routes.h
+++ b/felix/bpf-gpl/routes.h
@@ -96,7 +96,6 @@ static CALI_BPF_INLINE enum cali_rt_flags cali_rt_lookup_flags(ipv46_addr_t *add
 #define cali_rt_flags_local_tunneled_host(t) (((t) & (CALI_RT_LOCAL | CALI_RT_HOST | CALI_RT_TUNNELED)) == (CALI_RT_LOCAL | CALI_RT_HOST | CALI_RT_TUNNELED))
 #define cali_rt_flags_is_in_pool(t) (((t) & CALI_RT_IN_POOL) == CALI_RT_IN_POOL)
 #define cali_rt_flags_skip_ingress_redirect(t) (((t) & CALI_RT_SKIP_INGRESS_REDIRECT))
-#define cali_rt_flags_external(t) (!((t) & (CALI_RT_WORKLOAD | CALI_RT_HOST)))
 
 static CALI_BPF_INLINE bool rt_addr_is_local_host(ipv46_addr_t *addr)
 {
@@ -118,22 +117,17 @@ static CALI_BPF_INLINE bool rt_addr_is_local_tunneled_host(ipv46_addr_t *addr)
 	return cali_rt_flags_local_tunneled_host(cali_rt_lookup_flags(addr));
 }
 
-static CALI_BPF_INLINE bool rt_addr_is_external(ipv46_addr_t *addr)
-{
-	return cali_rt_flags_external(cali_rt_lookup_flags(addr));
-}
-
 static CALI_BPF_INLINE bool rt_addr_is_host_or_in_pool(ipv46_addr_t *addr)
 {
 	__u32 flags = cali_rt_lookup_flags(addr);
 	return cali_rt_flags_host(flags) || cali_rt_flags_is_in_pool(flags);
 }
 
-// Don't perform SNAT if either:
+// Traffic is NOT external if either:
 // - packet is destined to an address in an IP pool;
 // - packet is destined to local host; or
 // - packet is destined to a host and the CALI_GLOBALS_NATOUTGOING_EXCLUDE_HOSTS global flag is set
-static CALI_BPF_INLINE bool rt_flags_should_perform_nat_outgoing(enum cali_rt_flags flags, bool exclude_hosts)
+static CALI_BPF_INLINE bool rt_flags_external(enum cali_rt_flags flags, bool exclude_hosts)
 {
     if cali_rt_flags_is_in_pool(flags) return false;
     if cali_rt_flags_host(flags) {
@@ -142,4 +136,10 @@ static CALI_BPF_INLINE bool rt_flags_should_perform_nat_outgoing(enum cali_rt_fl
     }
     return true;
 }
+
+static CALI_BPF_INLINE bool rt_addr_is_external(ipv46_addr_t *addr, bool exclude_hosts)
+{
+	return rt_flags_external(cali_rt_lookup_flags(addr), exclude_hosts);
+}
+
 #endif /* __CALI_ROUTES_H__ */

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -536,27 +536,21 @@ syn_force_policy:
 		}
 
 		// Check whether the workload needs outgoing NAT to this address.
-		if (r->flags & CALI_RT_NAT_OUT) {
-			struct cali_rt *rt = cali_rt_lookup(&ctx->state->post_nat_ip_dst);
-			enum cali_rt_flags flags = CALI_RT_UNKNOWN;
-			if (rt) {
-				flags = rt->flags;
-			}
-			bool exclude_hosts = (GLOBAL_FLAGS & CALI_GLOBALS_NATOUTGOING_EXCLUDE_HOSTS);
-			if (rt_flags_should_perform_nat_outgoing(flags, exclude_hosts)) {
-				CALI_DEBUG("Source is in NAT-outgoing pool but dest is not, need to SNAT.");
-				ctx->state->flags |= CALI_ST_NAT_OUTGOING;
-			}
+		if ((r->flags & CALI_RT_NAT_OUT) &&
+			(rt_addr_is_external(&ctx->state->post_nat_ip_dst, GLOBAL_FLAGS & CALI_GLOBALS_NATOUTGOING_EXCLUDE_HOSTS))) {
+			CALI_DEBUG("Source is in NAT-outgoing pool but dest is not, need to SNAT.");
+			ctx->state->flags |= CALI_ST_NAT_OUTGOING;
 		}
 		// Check if traffic is leaving cluster. We might need to set DSCP later.
-		if (cali_rt_flags_is_in_pool(r->flags) && rt_addr_is_external(&ctx->state->post_nat_ip_dst)) {
+		if (cali_rt_flags_is_in_pool(r->flags) && rt_addr_is_external(&ctx->state->post_nat_ip_dst, false)) {
 			CALI_DEBUG("Outside cluster dest " IP_FMT "", debug_ip(ctx->state->post_nat_ip_dst));
 			ctx->state->flags |= CALI_ST_CLUSTER_EXTERNAL;
 		}
 		/* If 3rd party CNI is used and dest is outside cluster. See commit fc711b192f for details. */
 		if (!(cali_rt_flags_is_in_pool(r->flags))) {
 			CALI_DEBUG("Source " IP_FMT " not in IP pool", debug_ip(ctx->state->ip_src));
-			if (rt_addr_is_external(&ctx->state->post_nat_ip_dst)) {
+			r = cali_rt_lookup(&ctx->state->post_nat_ip_dst);
+			if (!r || !(r->flags & (CALI_RT_WORKLOAD | CALI_RT_HOST))) {
 				CALI_DEBUG("Outside cluster dest " IP_FMT "", debug_ip(ctx->state->post_nat_ip_dst));
 				ctx->state->flags |= CALI_ST_SKIP_FIB;
 			}
@@ -565,12 +559,12 @@ syn_force_policy:
 
 	// If either source or destination is outside cluster, set flag as might need to update DSCP later.
 	if ((CALI_F_TO_HEP) && (rt_addr_is_local_host(&ctx->state->ip_src)) &&
-		(rt_addr_is_external(&ctx->state->post_nat_ip_dst))) {
+		(rt_addr_is_external(&ctx->state->post_nat_ip_dst, false))) {
 		CALI_DEBUG("Outside cluster dest " IP_FMT "", debug_ip(ctx->state->post_nat_ip_dst));
 		ctx->state->flags |= CALI_ST_CLUSTER_EXTERNAL;
 	}
 	if ((CALI_F_FROM_HEP) && (rt_addr_is_host_or_in_pool(&ctx->state->post_nat_ip_dst)) &&
-		(rt_addr_is_external(&ctx->state->ip_src))) {
+		(rt_addr_is_external(&ctx->state->ip_src, false))) {
 		CALI_DEBUG("Outside cluster source " IP_FMT "", debug_ip(ctx->state->ip_src));
 		ctx->state->flags |= CALI_ST_CLUSTER_EXTERNAL;
 	}

--- a/felix/bpf/ut/qos_test.go
+++ b/felix/bpf/ut/qos_test.go
@@ -191,8 +191,8 @@ func TestDSCPv4_HEP(t *testing.T) {
 		{"calico_to_host_ep", tcdefs.MarkSeen, externalAddr, srcIP, resTC_ACT_UNSPEC, 8, -1},
 		{"calico_from_host_ep", 0, externalAddr, dstIP, resTC_ACT_UNSPEC, 40, -1},
 
-		// Src and dest both inside cluster.
-		{"calico_to_host_ep", tcdefs.MarkSeen, srcIP, dstIP, resTC_ACT_UNSPEC, 8, -1},
+		// Src and dest are both hosts.
+		{"calico_to_host_ep", tcdefs.MarkSeen, srcIP, dstIP, resTC_ACT_UNSPEC, 8, 8},
 	} {
 		skbMark = tc.expectedSKBMark
 		runBpfTest(t, tc.progName, rulesAllowUDP, func(bpfrun bpfProgRunFn) {
@@ -272,7 +272,7 @@ func TestDSCPv6_HEP(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 
 	rtKey = routes.NewKeyV6(dstV6CIDR).AsBytes()
-	rtVal = routes.NewValueV6WithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, ifIndex).AsBytes()
+	rtVal = routes.NewValueV6WithIfIndex(routes.FlagsRemoteHost, ifIndex).AsBytes()
 	err = rtMapV6.Update(rtKey, rtVal)
 	Expect(err).NotTo(HaveOccurred())
 	defer resetRTMap(rtMapV6)
@@ -288,8 +288,8 @@ func TestDSCPv6_HEP(t *testing.T) {
 		{"calico_to_host_ep", tcdefs.MarkSeen, externalAddr, dstIPv6, resTC_ACT_UNSPEC, 8, -1},
 		{"calico_from_host_ep", 0, externalAddr, dstIPv6, resTC_ACT_UNSPEC, 40, -1},
 
-		// Src and dest both inside cluster.
-		{"calico_to_host_ep", tcdefs.MarkSeen, srcIPv6, dstIPv6, resTC_ACT_UNSPEC, 8, -1},
+		// Src and dest both hosts.
+		{"calico_to_host_ep", tcdefs.MarkSeen, srcIPv6, dstIPv6, resTC_ACT_UNSPEC, 8, 8},
 	} {
 		skbMark = tc.expectedSKBMark
 		runBpfTest(t, tc.progName, rulesDefaultAllow, func(bpfrun bpfProgRunFn) {


### PR DESCRIPTION
Benchmark sample reproducing the **as-first-reviewed** state of [projectcalico/calico#10997](https://github.com/projectcalico/calico/pull/10997) (by @mazdakn).

This PR's diff equals what the human reviewers first saw: fork point `8001ccaeac01` → earliest human-reviewed commit `5eddd50fb7f5`. The original PR drew **8** human top-level review comments — the ground truth to compare the Council's feedback against.

🤖 Generated for the Council of Claudes benchmark.