### PR TITLE
Re-add cherry-pick-candidate auto-labeler with Copilot review fixes

### DIFF
--- a/.github/workflows/cherry_pick_candidate.yml
+++ b/.github/workflows/cherry_pick_candidate.yml
@@ -1,0 +1,61 @@
+# Stage 2 of the cherry-pick-candidate auto-labeler. Triggered by
+# workflow_run when "Cherry-Pick Candidate (trigger)" completes.
+#
+# Asks the calico-backport-classifier agent whether the PR looks like a
+# backport candidate based on its title + body, and reconciles the
+# `cherry-pick-candidate` label:
+#   agent says backport, label absent       : add label
+#   agent says skip, label present (by bot) : remove label
+#   any human action on the label           : leave it alone
+#
+# Trust model: stage 1 may execute fork-modified code from the PR head,
+# but it has zero permissions. Stage 2 runs from the base branch (trusted
+# workflow file) with contents:read + pull-requests:write + issues:write.
+# PR identity comes from GitHub-set workflow_run.head_sha, never from
+# artifact content. All logic lives in
+# .github/workflows/scripts/cherry_pick_candidate.js, loaded from the
+# trusted base-branch tree via actions/checkout.
+#
+# No-op until the BACKPORT_CLASSIFIER_AGENT_URL and
+# BACKPORT_CLASSIFIER_AGENT_TOKEN repo secrets are set: the script
+# short-circuits with a warning if either is missing.
+
+name: Cherry-Pick Candidate
+on:
+  workflow_run:
+    workflows: ["Cherry-Pick Candidate (trigger)"]
+    types: [completed]
+
+concurrency:
+  # Key per (fork owner, branch) so events for the same PR coalesce,
+  # including force-pushes that change head_sha.
+  group: cherry-pick-candidate-${{ github.event.workflow_run.head_repository.owner.login }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  classify:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    env:
+      AGENT_URL: ${{ secrets.BACKPORT_CLASSIFIER_AGENT_URL }}
+      AGENT_TOKEN: ${{ secrets.BACKPORT_CLASSIFIER_AGENT_TOKEN }}
+    steps:
+      # workflow_run runs in the context of the base branch, so checkout
+      # without a `ref:` gets the trusted default-branch tree, not the
+      # fork PR's. persist-credentials:false drops the git token after
+      # this step (we only need it to read the .js file).
+      - name: Checkout workflow scripts
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Classify and reconcile label
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const fn = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/cherry_pick_candidate.js`);
+            await fn({ github, context, core });

--- a/.github/workflows/cherry_pick_candidate_trigger.yml
+++ b/.github/workflows/cherry_pick_candidate_trigger.yml
@@ -1,0 +1,19 @@
+# Stage 1 of the cherry-pick-candidate auto-labeler. Fires on PR open,
+# reopen, and title/body edits with zero permissions and no logic. Sole
+# purpose: fire a workflow_run event so the trusted stage 2
+# (cherry_pick_candidate.yml) can do the real work from the base branch
+# with the privileged token.
+
+name: Cherry-Pick Candidate (trigger)
+on:
+  pull_request:
+    types: [opened, reopened, edited]
+
+permissions: {}
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - run: echo "Triggers Cherry-Pick Candidate via workflow_run."

--- a/.github/workflows/scripts/cherry_pick_candidate.js
+++ b/.github/workflows/scripts/cherry_pick_candidate.js
@@ -1,0 +1,159 @@
+// Reconciles the `cherry-pick-candidate` label on master PRs based on an
+// external LLM classifier agent's verdict. Invoked from the Stage 2
+// cherry-pick-candidate workflow via actions/github-script.
+//
+// Rules:
+//   agent says backport, label absent       : add label
+//   agent says skip, label present (by bot) : remove label
+//   any non-bot action on the label         : leave it alone (for the
+//                                             rest of the PR's life)
+//
+// The whole job is a no-op until the BACKPORT_CLASSIFIER_AGENT_URL and
+// BACKPORT_CLASSIFIER_AGENT_TOKEN repo secrets are set (passed in to
+// this script as AGENT_URL and AGENT_TOKEN env vars by the workflow).
+
+const LABEL = 'cherry-pick-candidate';
+const BOT_LOGIN = 'github-actions[bot]';
+
+module.exports = async ({ github, context, core }) => {
+  const { owner, repo } = context.repo;
+  const agentUrl = process.env.AGENT_URL;
+  const agentToken = process.env.AGENT_TOKEN;
+  if (!agentUrl || !agentToken) {
+    core.warning('BACKPORT_CLASSIFIER_AGENT_URL or BACKPORT_CLASSIFIER_AGENT_TOKEN secret missing (read by this script as AGENT_URL/AGENT_TOKEN env vars), skipping');
+    return;
+  }
+
+  const headSha = context.payload.workflow_run?.head_sha;
+  if (!headSha) {
+    core.warning('workflow_run payload missing head_sha, skipping');
+    return;
+  }
+
+  // 1. Find the open master PR for this head SHA.
+  const associated = await github.paginate(
+    github.rest.repos.listPullRequestsAssociatedWithCommit,
+    { owner, repo, commit_sha: headSha },
+  );
+  const pr = associated.find(p =>
+    p.state === 'open' && p.head.sha === headSha && p.base.ref === 'master',
+  );
+  if (!pr) {
+    core.warning(`no open master PR found with head SHA ${headSha}, skipping`);
+    return;
+  }
+
+  // 2. Authority check. The most recent labeled/unlabeled event for this
+  //    label tells us who currently owns it. Any actor other than
+  //    github-actions[bot] is final.
+  const events = await github.paginate(
+    github.rest.issues.listEventsForTimeline,
+    { owner, repo, issue_number: pr.number },
+  );
+  const labelEvents = events.filter(e =>
+    (e.event === 'labeled' || e.event === 'unlabeled') && e.label?.name === LABEL,
+  );
+  const lastActor = labelEvents[labelEvents.length - 1]?.actor?.login || '';
+  if (lastActor && lastActor !== BOT_LOGIN) {
+    core.info(`Label authority: ${lastActor} (non-bot), bot will not modify`);
+    return;
+  }
+  const present = pr.labels.some(l => l.name === LABEL);
+  core.info(`Label authority: bot (last actor: ${lastActor || 'none'}, present=${present})`);
+
+  // 3. Call the classifier agent. Up to 3 attempts with 5s, 10s backoff.
+  const msgId = `calico-backport-classifier-${pr.number}-${process.env.GITHUB_RUN_ID}`;
+  const payload = {
+    jsonrpc: '2.0',
+    id: msgId,
+    method: 'message/send',
+    params: {
+      message: {
+        messageId: msgId,
+        role: 'user',
+        parts: [{
+          kind: 'text',
+          text: `PR number: ${pr.number}\nPR title: ${pr.title}\nPR body:\n${pr.body || ''}`,
+        }],
+      },
+      configuration: { acceptedOutputModes: ['application/json', 'text/plain'] },
+    },
+  };
+
+  let response = null;
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const r = await fetch(agentUrl, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${agentToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(60_000),
+      });
+      if (r.ok) {
+        response = await r.json();
+        break;
+      }
+      core.info(`agent attempt ${attempt} failed (http=${r.status})`);
+    } catch (e) {
+      core.info(`agent attempt ${attempt} failed (${e.message})`);
+    }
+    if (attempt < 3) await new Promise(res => setTimeout(res, attempt * 5000));
+  }
+  if (!response) {
+    core.warning('agent unreachable after 3 attempts, skipping');
+    return;
+  }
+
+  // 4. Parse the response. Contract: result.artifacts[0].parts[0].text is
+  //    a JSON object with fields decision (backport|skip), confidence,
+  //    primary_signal, reason. Tolerated wrapped in a markdown fence.
+  const raw = response.result?.artifacts?.[0]?.parts?.[0]?.text || '';
+  const stripped = raw.replace(/^```(?:json)?\s*\n?|\n?```\s*$/gm, '').trim();
+  let parsed;
+  try {
+    parsed = JSON.parse(stripped);
+  } catch (e) {
+    core.warning(`could not parse agent response: ${e.message}`);
+    core.info(`raw response: ${JSON.stringify(response).slice(0, 500)}`);
+    return;
+  }
+  const { decision, confidence, primary_signal: primarySignal, reason } = parsed;
+  if (decision !== 'backport' && decision !== 'skip') {
+    core.warning(`unknown decision: ${decision}, skipping`);
+    return;
+  }
+  // Sanitize agent-controlled text before logging so it cannot inject
+  // ::add-mask:: or other workflow commands via the reason field.
+  const safe = s => String(s ?? '').replace(/::/g, ':​:');
+  core.info(`agent decision: ${decision} (confidence=${safe(confidence)})`);
+  core.info(`primary signal: ${safe(primarySignal)}`);
+  core.info(`reason: ${safe(reason)}`);
+
+  // 5. Reconcile. addLabels is idempotent server-side; removeLabel 404s if
+  //    the label was removed by a human during the agent call (we treat
+  //    that as a no-op since the end state matches our intent).
+  if (decision === 'backport' && !present) {
+    core.info(`Adding ${LABEL} to PR #${pr.number}`);
+    await github.rest.issues.addLabels({
+      owner, repo, issue_number: pr.number, labels: [LABEL],
+    });
+  } else if (decision === 'skip' && present) {
+    core.info(`Removing ${LABEL} from PR #${pr.number} (bot-applied, agent now says skip)`);
+    try {
+      await github.rest.issues.removeLabel({
+        owner, repo, issue_number: pr.number, name: LABEL,
+      });
+    } catch (e) {
+      if (e.status === 404) {
+        core.info('label already gone, no-op');
+      } else {
+        throw e;
+      }
+    }
+  } else {
+    core.info(`No-op (decision=${decision}, present=${present})`);
+  }
+};


### PR DESCRIPTION
## Summary

Brings the cherry-pick-candidate auto-labeler workflow back into this repo (it was overwritten when master last synced from `projectcalico/calico`), with four wording / clarity fixes from the Copilot review on projectcalico/calico#12926 folded in.

This is the same content that will land in projectcalico/calico once that PR is updated, so testing here gives us confidence before the public PR moves.

## Files

- `.github/workflows/cherry_pick_candidate_trigger.yml` (19 lines) — Stage 1, fires on `pull_request` with `permissions: {}`.
- `.github/workflows/cherry_pick_candidate.yml` (61 lines) — Stage 2, runs from the trusted base-branch tree via `workflow_run`, calls the script via `actions/github-script`.
- `.github/workflows/scripts/cherry_pick_candidate.js` (158 lines) — all classification and reconcile logic.

## Copilot fixes applied

1. Header rules table: "any human action on the label" tightened to "any non-bot action" — other bot accounts (Renovate, Dependabot) would have looked like human authority under the old wording.
2. Inline comment at the authority check now names the bot explicitly: "any actor other than `github-actions[bot]` is final".
3. Header comment clarifies that `BACKPORT_CLASSIFIER_AGENT_URL` and `BACKPORT_CLASSIFIER_AGENT_TOKEN` are repo secrets, passed in to the script as `AGENT_URL`/`AGENT_TOKEN` env vars by the workflow.
4. Missing-secret warning mentions both the secret name and the env-var name so an operator reading workflow logs can find them.

Plus a small consistency tweak: log line "Label authority: human (X)" became "Label authority: X (non-bot)" so it matches the corrected wording.

Copilot's 5th comment (downgrade `pull-requests: write` to `read`) was not applied — we hit that exact case earlier and confirmed it returns 403 on the label-write API call against PRs.

## Configuration

Two repo secrets are required:

- `BACKPORT_CLASSIFIER_AGENT_URL`
- `BACKPORT_CLASSIFIER_AGENT_TOKEN`

If either is missing, the job emits a warning and exits cleanly. Landing this PR before the secrets are configured is safe.

## Test plan after merge

- [ ] Open a bug-fix-shaped PR (panic / leak / race / security hardening), confirm `cherry-pick-candidate` is applied within ~30s.
- [ ] Open a feature or refactor PR, confirm no label is applied.
- [ ] On a bot-labeled PR, edit the title to a feature shape, confirm the label is removed.
- [ ] Manually remove a bot-applied label, edit the PR, confirm the bot does not re-apply.
- [ ] Manually add the label to a feature-shaped PR, confirm the bot does not remove it.

Once green here we can update projectcalico/calico#12926 with the same fixes.