### PR TITLE
cherry-pick-candidate: small follow-ups from Council of Claudes review

### DIFF
--- a/.github/workflows/cherry_pick_candidate.yml
+++ b/.github/workflows/cherry_pick_candidate.yml
@@ -6,7 +6,7 @@
 # `cherry-pick-candidate` label:
 #   agent says backport, label absent       : add label
 #   agent says skip, label present (by bot) : remove label
-#   any human action on the label           : leave it alone
+#   any non-bot action on the label         : leave it alone
 #
 # Trust model: stage 1 may execute fork-modified code from the PR head,
 # but it has zero permissions. Stage 2 runs from the base branch (trusted
@@ -39,6 +39,9 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      # pull-requests: write is required to add or remove labels on PRs.
+      # issues: write alone returns 403 against /issues/{n}/labels when
+      # the target is a PR. Do not tighten this back to read.
       pull-requests: write
       issues: write
     env:

--- a/.github/workflows/scripts/cherry_pick_candidate.js
+++ b/.github/workflows/scripts/cherry_pick_candidate.js
@@ -23,6 +23,15 @@ module.exports = async ({ github, context, core }) => {
     core.warning('BACKPORT_CLASSIFIER_AGENT_URL or BACKPORT_CLASSIFIER_AGENT_TOKEN secret missing (read by this script as AGENT_URL/AGENT_TOKEN env vars), skipping');
     return;
   }
+  // Register the token for log masking so it cannot leak via any
+  // downstream log line, including diagnostics added later.
+  core.setSecret(agentToken);
+  // Refuse to send the bearer token over plaintext if a misconfigured
+  // secret points at a non-https URL.
+  if (!/^https:\/\//i.test(agentUrl)) {
+    core.warning('AGENT_URL is not https://, refusing to send bearer token over plaintext, skipping');
+    return;
+  }
 
   const headSha = context.payload.workflow_run?.head_sha;
   if (!headSha) {
@@ -90,6 +99,9 @@ module.exports = async ({ github, context, core }) => {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(payload),
+        // Fail closed on any redirect so the bearer token cannot be
+        // sent to a different host than the configured AGENT_URL.
+        redirect: 'error',
         signal: AbortSignal.timeout(60_000),
       });
       if (r.ok) {


### PR DESCRIPTION
## Summary

Five small fixes folded in from the Council of Claudes review on #202. Net: 16 lines added, 1 changed.

## Security (defense in depth)

1. `core.setSecret(agentToken)` at startup. The runner now masks the bearer token wherever it might appear in logs, covering both today's code paths and any diagnostic line added later.
2. `redirect: 'error'` on the agent `fetch`. The bearer token cannot be transmitted to a host other than the configured `AGENT_URL`, even if someone misconfigures the secret to point at a redirector.
3. Refuse to send the bearer token if `AGENT_URL` is not `https://`. Cheap guard against a misconfigured repo secret pointing at a plaintext endpoint.

## Consistency / future-proofing

4. YAML header comment was still saying "any human action" while the JS now uses "any non-bot action". Aligned.
5. Comment near `permissions:` explaining why `pull-requests: write` is required (the `issues: write alone returns 403 against /issues/{n}/labels` empirical lesson). This is the fourth time a reviewer has suggested dropping it back to `read`; encoding the reason next to the code should head off the fifth.

## Skipped from the Council review (and why)

- Switch to `workflow_run.pull_requests` for PR identification: that field is empty for fork PRs, which is precisely why we use the SHA-lookup path.
- Re-check authority right before mutation: we explicitly chose to drop this earlier; the race window is small and worst case is a 404 (handled) or an idempotent POST.
- Drop `pull-requests: write` to `read`: empirically returns 403 on the label-write API. (See fix #5 above.)
- Make base branch configurable: over-engineering for `master` which is stable.
- `iterator + early-break` on timeline: bot was wrong about ordering (events are oldest-first); current code is correct.
- Extract `parseAgentResponse` for unit tests, add DRY_RUN mode, pre-create label if missing: nice-to-haves, deferred until first incident.

## Test plan after merge

- [ ] Open a bug-fix-shaped PR, confirm `cherry-pick-candidate` is applied.
- [ ] Open a feature PR, confirm no label.
- [ ] In a workflow run log, confirm the bearer token is masked anywhere it appears (look for `***`).
- [ ] (Manual, optional) Set `BACKPORT_CLASSIFIER_AGENT_URL` to an `http://` value, confirm the workflow warns and skips.