### PR TITLE
cherry-pick-candidate: address @tomastigera's review (sanitize raw-response log, fix concurrency comment)

### DIFF
--- a/.github/workflows/cherry_pick_candidate.yml
+++ b/.github/workflows/cherry_pick_candidate.yml
@@ -27,8 +27,10 @@ on:
     types: [completed]
 
 concurrency:
-  # Key per (fork owner, branch) so events for the same PR coalesce,
-  # including force-pushes that change head_sha.
+  # Key per (fork owner, branch) so rapid edits to the same PR coalesce
+  # via cancel-in-progress and only the latest edited state runs to
+  # completion. Code pushes do not fire Stage 1 (synchronize is not in
+  # the trigger types), so this key is about user-driven title/body edits.
   group: cherry-pick-candidate-${{ github.event.workflow_run.head_repository.owner.login }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 

--- a/.github/workflows/scripts/cherry_pick_candidate.js
+++ b/.github/workflows/scripts/cherry_pick_candidate.js
@@ -32,6 +32,10 @@ module.exports = async ({ github, context, core }) => {
     core.warning('AGENT_URL is not https://, refusing to send bearer token over plaintext, skipping');
     return;
   }
+  // Neutralize :: in agent-controlled text before logging so the agent
+  // cannot inject ::add-mask:: or other workflow commands. Used for every
+  // line that echoes any byte the agent could have authored.
+  const safe = s => String(s ?? '').replace(/::/g, ':​:');
 
   const headSha = context.payload.workflow_run?.head_sha;
   if (!headSha) {
@@ -129,7 +133,7 @@ module.exports = async ({ github, context, core }) => {
     parsed = JSON.parse(stripped);
   } catch (e) {
     core.warning(`could not parse agent response: ${e.message}`);
-    core.info(`raw response: ${JSON.stringify(response).slice(0, 500)}`);
+    core.info(safe(`raw response: ${JSON.stringify(response).slice(0, 500)}`));
     return;
   }
   const { decision, confidence, primary_signal: primarySignal, reason } = parsed;
@@ -137,9 +141,6 @@ module.exports = async ({ github, context, core }) => {
     core.warning(`unknown decision: ${decision}, skipping`);
     return;
   }
-  // Sanitize agent-controlled text before logging so it cannot inject
-  // ::add-mask:: or other workflow commands via the reason field.
-  const safe = s => String(s ?? '').replace(/::/g, ':​:');
   core.info(`agent decision: ${decision} (confidence=${safe(confidence)})`);
   core.info(`primary signal: ${safe(primarySignal)}`);
   core.info(`reason: ${safe(reason)}`);


### PR DESCRIPTION
## Summary

Two small follow-ups from the review on projectcalico/calico#12926. Mirrors the fixes already pushed to that PR.

## Changes

1. **Wrap the parse-failure debug log in `safe()`** (security consistency).

   `cherry_pick_candidate.js` had one log line that echoed agent-controlled bytes without going through `safe()`:

   ```js
   core.info(`raw response: ${JSON.stringify(response).slice(0, 500)}`);
   ```

   `JSON.stringify` doesn't escape `::`, so an agent that emits text like `::add-mask::FOO` in its response body could still inject workflow commands into the runner log via this diagnostic path — exactly what `safe()` was added to prevent on the `reason` / `primary_signal` / `confidence` lines. Wrap this line too and hoist `safe()` to the top of the function so it covers every path that touches agent-controlled bytes.

2. **Reword the concurrency-key comment** (doc accuracy).

   The comment said the key handles "force-pushes that change `head_sha`," but the trigger types are `[opened, reopened, edited]` (`synchronize` is intentionally excluded), so force-pushes don't fire Stage 1 at all. The key is really about coalescing rapid title/body edits. Reworded to match.

## Diff stat

`+9 / -6` across the two files.

## Test plan after merge

- [ ] Open a bug-fix-shaped PR, confirm `cherry-pick-candidate` is applied.
- [ ] Open a feature PR, confirm no label.
- [ ] Confirm the bearer token remains masked in logs (still 0 raw occurrences expected).