### PR TITLE
cherry-pick-candidate: fix PR lookup so it works for fork PRs

### DIFF
--- a/.github/workflows/scripts/cherry_pick_candidate.js
+++ b/.github/workflows/scripts/cherry_pick_candidate.js
@@ -44,15 +44,37 @@ module.exports = async ({ github, context, core }) => {
   }
 
   // 1. Find the open master PR for this head SHA.
-  const associated = await github.paginate(
-    github.rest.repos.listPullRequestsAssociatedWithCommit,
-    { owner, repo, commit_sha: headSha },
-  );
-  const pr = associated.find(p =>
-    p.state === 'open' && p.head.sha === headSha && p.base.ref === 'master',
-  );
-  if (!pr) {
-    core.warning(`no open master PR found with head SHA ${headSha}, skipping`);
+  // search/issues is fork-friendly: the /repos/.../commits/{sha}/pulls
+  // endpoint (which listPullRequestsAssociatedWithCommit wraps) returns
+  // nothing for fork PRs because the head commit lives on the fork's
+  // repo, not the base repo's commit DAG. The search index can lag a
+  // few seconds for very fresh commits, so we retry once after 5s.
+  let prNumber = null;
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    const { data: search } = await github.rest.search.issuesAndPullRequests({
+      q: `repo:${owner}/${repo} is:pr sha:${headSha}`,
+    });
+    const hit = search.items.find(i => i.state === 'open');
+    if (hit) {
+      prNumber = hit.number;
+      break;
+    }
+    if (attempt === 1) {
+      core.info(`Search index empty for ${headSha}, retrying in 5s`);
+      await new Promise(r => setTimeout(r, 5000));
+    }
+  }
+  if (!prNumber) {
+    core.warning(`no open PR found with head SHA ${headSha}, skipping`);
+    return;
+  }
+  // Confirm base.ref and head.sha via the PR API; search returns
+  // issue-shaped results that don't carry those fields.
+  const { data: pr } = await github.rest.pulls.get({
+    owner, repo, pull_number: prNumber,
+  });
+  if (pr.base.ref !== 'master' || pr.head.sha !== headSha || pr.state !== 'open') {
+    core.info(`PR #${pr.number} no longer matches expected state (base=${pr.base.ref}, head_sha=${pr.head.sha}, state=${pr.state}), skipping`);
     return;
   }
 


### PR DESCRIPTION
## What

The PR lookup in `cherry_pick_candidate.js` used `listPullRequestsAssociatedWithCommit`, which calls `GET /repos/{owner}/{repo}/commits/{sha}/pulls`. That endpoint only walks the base repo's main commit DAG, so it returns **empty for fork PRs** (the head commit lives on the fork repo, not the base; even after GitHub fetches it into `refs/pull/N/head`, the endpoint doesn't see it).

That broke the workflow in production on `projectcalico/calico`: a draft test PR from `skoryk-oleksandr/calico` fired Stage 2, the script looked up the PR by head SHA, got nothing, and hit the "no open master PR found" skip path. See run https://github.com/projectcalico/calico/actions/runs/27636229884.

Same-repo PRs worked because their head SHA is in the base repo's main graph by definition. Every test we ran in this repo (`tigera/calico-oss-test`) was a same-repo PR (`git push -u origin test/cp-...` then `gh pr create --base master --head test/cp-...`), so the broken path was never exercised in staging. The Copilot reviewer on #12926 called this out; that comment was right and I was wrong to dismiss it.

## Fix

Switch to `search.issuesAndPullRequests` with `repo:O/N is:pr sha:S` — this finds both fork and same-repo PRs. After matching, confirm `base.ref` and `head.sha` via a `pulls.get` so we never act on a stale or wrong-base hit (search returns issue-shaped objects that lack those fields). Adds a single retry after 5s to absorb search-index lag on fresh commits.

Diff: +31 / -9 in the JS file. No YAML changes, no permission changes (search and pulls.get are covered by the existing `issues: write` / `pull-requests: write` / `contents: read` token).

## Test plan

- [ ] Merge.
- [ ] Open a same-repo bug-fix-shaped PR (regression check); confirm label is applied.
- [ ] Open a fork PR (new coverage) targeting this repo's master; confirm label is applied.
- [ ] Open a feature/refactor PR; confirm no label.

Once green, push the same patch to `projectcalico/calico` master (currently has the broken lookup).