### PR TITLE
Council of Claudes: orchestrator agent for cross-persona comment dedup

### DIFF
--- a/.github/workflows/council_of_claudes.yml
+++ b/.github/workflows/council_of_claudes.yml
@@ -43,6 +43,9 @@ jobs:
       NELLJERRAM_AGENT_TOKEN: ${{ secrets.NELLJERRAM_AGENT_TOKEN }}
       CASEYDAVENPORT_AGENT_URL: ${{ secrets.CASEYDAVENPORT_AGENT_URL }}
       CASEYDAVENPORT_AGENT_TOKEN: ${{ secrets.CASEYDAVENPORT_AGENT_TOKEN }}
+      # Orchestrator (cross-persona dedup); if unset, all comments are posted unfiltered.
+      ORCHESTRATOR_AGENT_URL: ${{ secrets.ORCHESTRATOR_AGENT_URL }}
+      ORCHESTRATOR_AGENT_TOKEN: ${{ secrets.ORCHESTRATOR_AGENT_TOKEN }}
     steps:
       # pull_request checks out the merge ref by default, so the script comes
       # from the PR's own tree — letting us iterate on the workflow via its PR.

--- a/.github/workflows/scripts/council_of_claudes.js
+++ b/.github/workflows/scripts/council_of_claudes.js
@@ -226,11 +226,12 @@ const ORCH_URL_ENV = 'ORCHESTRATOR_AGENT_URL';
 const ORCH_TOKEN_ENV = 'ORCHESTRATOR_AGENT_TOKEN';
 
 // Robustly extract the orchestrator's { clusters: [...] } JSON from its response
-// (tolerates a ```json fence or stray prose). Returns the parsed object or null.
+// (tolerates a ```json fence — single- or multi-line — or stray prose). Returns
+// the parsed object or null.
 function parseClusters(text) {
   if (!text) return null;
   const tries = [text.trim()];
-  const fence = text.match(/```[a-zA-Z]*\s*\n([\s\S]*?)\n```/);
+  const fence = text.match(/```[a-zA-Z]*\s*([\s\S]*?)```/); // handles single-line fences too
   if (fence) tries.push(fence[1].trim());
   const first = text.indexOf('{'), last = text.lastIndexOf('}');
   if (first !== -1 && last > first) tries.push(text.slice(first, last + 1));
@@ -243,10 +244,38 @@ function parseClusters(text) {
   return null;
 }
 
+// Pure decision logic: given the inline comments and the orchestrator's parsed
+// clusters, return the SET of ids to drop. No env / network — directly unit
+// testable. Defensive against arbitrary LLM output: honor a cluster only if its
+// survivor is a known id; drop only known duplicate ids; keep-wins (an id that
+// survives anywhere is never dropped); anything not mentioned is implicitly kept.
+function applyClusters({ core, allInline, parsed }) {
+  const known = new Set(allInline.map(c => c.id));
+  const survivors = new Set();
+  const candidates = new Set();
+  for (const cl of parsed.clusters) {
+    // Every field here is LLM-controlled / possibly garbage — guard each access.
+    if (!cl || typeof cl.survivor !== 'string' || !known.has(cl.survivor)) continue;
+    survivors.add(cl.survivor);
+    const dups = Array.isArray(cl.duplicates) ? cl.duplicates.filter(d => known.has(d)) : [];
+    dups.forEach(d => candidates.add(d));
+    if (dups.length) core.info(`  orchestrator: keep ${cl.survivor}, drop [${dups.join(', ')}] — ${safe(cl.reason)}`);
+  }
+  // The prompt says each id appears at most once; if the model listed an id as
+  // both a survivor and a duplicate, keep-wins silently saves it — warn so a
+  // misbehaving orchestrator is visible rather than silently absorbed.
+  const conflicts = [...candidates].filter(id => survivors.has(id));
+  if (conflicts.length) core.warning(`Orchestrator: ${conflicts.length} id(s) listed as both survivor and duplicate (kept via keep-wins): ${conflicts.join(', ')}`);
+  const drop = new Set([...candidates].filter(id => !survivors.has(id)));
+  core.info(`Orchestrator: dropping ${drop.size} duplicate comment(s) of ${allInline.length} inline`);
+  return drop;
+}
+
 // Ask the orchestrator which inline comments are redundant duplicates and return
 // the SET of comment ids to drop. Lossless by construction: returns an empty set
 // (drop nothing → post everything) if the orchestrator is unconfigured, errors,
-// times out, or returns anything we can't safely apply.
+// times out, or returns anything we can't safely apply. The try/catch makes the
+// "post everything on failure" guarantee robust even if a callee starts throwing.
 async function orchestrateDedup({ core, allInline }) {
   const empty = new Set();
   const url = process.env[ORCH_URL_ENV];
@@ -255,36 +284,25 @@ async function orchestrateDedup({ core, allInline }) {
     core.info(`Orchestrator not configured (${ORCH_URL_ENV}/${ORCH_TOKEN_ENV} unset) — posting all comments`);
     return empty;
   }
-  if (allInline.length < 2) return empty; // nothing to dedupe
+  if (allInline.length < 2) return empty; // nothing to dedupe (need ≥2 comments)
 
-  const msgId = `council-orchestrator-${process.env.GITHUB_RUN_ID}`;
-  const payload = JSON.stringify(allInline.map(c =>
-    ({ id: c.id, persona: c.persona, file: c.file, line: c.line, body: c.body })));
-  const messageText =
-    `Here are ${allInline.length} inline review comments from one pull request, as a JSON array. ` +
-    `Identify redundant duplicate groups and return the clusters JSON per your instructions.\n\n${payload}`;
+  try {
+    const msgId = `council-orchestrator-${process.env.GITHUB_RUN_ID}`;
+    const payload = JSON.stringify(allInline.map(c =>
+      ({ id: c.id, persona: c.persona, file: c.file, line: c.line, body: c.body })));
+    const messageText =
+      `Here are ${allInline.length} inline review comments from one pull request, as a JSON array. ` +
+      `Identify redundant duplicate groups and return the clusters JSON per your instructions.\n\n${payload}`;
 
-  const out = await reviewWithAgent({ core, title: 'Orchestrator', url, token, messageText, msgId });
-  if (!out) { core.warning('Orchestrator: no response — posting all comments unfiltered'); return empty; }
-  const parsed = parseClusters(out);
-  if (!parsed) { core.warning('Orchestrator: unparseable response — posting all comments unfiltered'); return empty; }
-
-  // Apply defensively: honor a cluster only if its survivor is a known id; drop
-  // only known duplicate ids; keep-wins (an id that survives anywhere is never
-  // dropped). Anything not mentioned is implicitly kept.
-  const known = new Set(allInline.map(c => c.id));
-  const survivors = new Set();
-  const candidates = new Set();
-  for (const cl of parsed.clusters) {
-    if (!cl || typeof cl.survivor !== 'string' || !known.has(cl.survivor)) continue;
-    survivors.add(cl.survivor);
-    const dups = Array.isArray(cl.duplicates) ? cl.duplicates.filter(d => known.has(d)) : [];
-    dups.forEach(d => candidates.add(d));
-    if (dups.length) core.info(`  orchestrator: keep ${cl.survivor}, drop [${dups.join(', ')}] — ${safe(cl.reason)}`);
+    const out = await reviewWithAgent({ core, title: 'Orchestrator', url, token, messageText, msgId });
+    if (!out) { core.warning('Orchestrator: no response — posting all comments unfiltered'); return empty; }
+    const parsed = parseClusters(out);
+    if (!parsed) { core.warning('Orchestrator: unparseable response — posting all comments unfiltered'); return empty; }
+    return applyClusters({ core, allInline, parsed });
+  } catch (e) {
+    core.warning(`Orchestrator: unexpected error (${safe(e.message)}) — posting all comments unfiltered`);
+    return empty;
   }
-  const drop = new Set([...candidates].filter(id => !survivors.has(id)));
-  core.info(`Orchestrator: dropping ${drop.size} duplicate comment(s) of ${allInline.length} inline`);
-  return drop;
 }
 
 module.exports = async ({ github, context, core }) => {
@@ -378,6 +396,11 @@ module.exports = async ({ github, context, core }) => {
     const anchorable = [];
     findings.forEach((f, i) => {
       if (anchors.get(f.file)?.has(f.line)) {
+        // Run-scoped ephemeral id: generated and consumed within this single
+        // invocation (sent to the orchestrator, matched against its drop set).
+        // `i` is the index into `findings` (gaps where entries were folded are
+        // harmless — ids only need per-persona uniqueness); never persisted, so
+        // it must not be correlated across runs or against existingComments.
         const id = `${p.key}-${i}`;
         anchorable.push({ id, ...f });
         allInline.push({ id, persona: p.title, file: f.file, line: f.line, body: f.body });

--- a/.github/workflows/scripts/council_of_claudes.js
+++ b/.github/workflows/scripts/council_of_claudes.js
@@ -221,6 +221,72 @@ async function reviewWithAgent({ core, title, url, token, messageText, msgId }) 
   return null;
 }
 
+// --- Orchestrator: cross-persona deduplication of inline comments ---
+const ORCH_URL_ENV = 'ORCHESTRATOR_AGENT_URL';
+const ORCH_TOKEN_ENV = 'ORCHESTRATOR_AGENT_TOKEN';
+
+// Robustly extract the orchestrator's { clusters: [...] } JSON from its response
+// (tolerates a ```json fence or stray prose). Returns the parsed object or null.
+function parseClusters(text) {
+  if (!text) return null;
+  const tries = [text.trim()];
+  const fence = text.match(/```[a-zA-Z]*\s*\n([\s\S]*?)\n```/);
+  if (fence) tries.push(fence[1].trim());
+  const first = text.indexOf('{'), last = text.lastIndexOf('}');
+  if (first !== -1 && last > first) tries.push(text.slice(first, last + 1));
+  for (const t of tries) {
+    try {
+      const obj = JSON.parse(t);
+      if (obj && Array.isArray(obj.clusters)) return obj;
+    } catch { /* try next candidate */ }
+  }
+  return null;
+}
+
+// Ask the orchestrator which inline comments are redundant duplicates and return
+// the SET of comment ids to drop. Lossless by construction: returns an empty set
+// (drop nothing → post everything) if the orchestrator is unconfigured, errors,
+// times out, or returns anything we can't safely apply.
+async function orchestrateDedup({ core, allInline }) {
+  const empty = new Set();
+  const url = process.env[ORCH_URL_ENV];
+  const token = process.env[ORCH_TOKEN_ENV];
+  if (!url || !token) {
+    core.info(`Orchestrator not configured (${ORCH_URL_ENV}/${ORCH_TOKEN_ENV} unset) — posting all comments`);
+    return empty;
+  }
+  if (allInline.length < 2) return empty; // nothing to dedupe
+
+  const msgId = `council-orchestrator-${process.env.GITHUB_RUN_ID}`;
+  const payload = JSON.stringify(allInline.map(c =>
+    ({ id: c.id, persona: c.persona, file: c.file, line: c.line, body: c.body })));
+  const messageText =
+    `Here are ${allInline.length} inline review comments from one pull request, as a JSON array. ` +
+    `Identify redundant duplicate groups and return the clusters JSON per your instructions.\n\n${payload}`;
+
+  const out = await reviewWithAgent({ core, title: 'Orchestrator', url, token, messageText, msgId });
+  if (!out) { core.warning('Orchestrator: no response — posting all comments unfiltered'); return empty; }
+  const parsed = parseClusters(out);
+  if (!parsed) { core.warning('Orchestrator: unparseable response — posting all comments unfiltered'); return empty; }
+
+  // Apply defensively: honor a cluster only if its survivor is a known id; drop
+  // only known duplicate ids; keep-wins (an id that survives anywhere is never
+  // dropped). Anything not mentioned is implicitly kept.
+  const known = new Set(allInline.map(c => c.id));
+  const survivors = new Set();
+  const candidates = new Set();
+  for (const cl of parsed.clusters) {
+    if (!cl || typeof cl.survivor !== 'string' || !known.has(cl.survivor)) continue;
+    survivors.add(cl.survivor);
+    const dups = Array.isArray(cl.duplicates) ? cl.duplicates.filter(d => known.has(d)) : [];
+    dups.forEach(d => candidates.add(d));
+    if (dups.length) core.info(`  orchestrator: keep ${cl.survivor}, drop [${dups.join(', ')}] — ${safe(cl.reason)}`);
+  }
+  const drop = new Set([...candidates].filter(id => !survivors.has(id)));
+  core.info(`Orchestrator: dropping ${drop.size} duplicate comment(s) of ${allInline.length} inline`);
+  return drop;
+}
+
 module.exports = async ({ github, context, core }) => {
   const { owner, repo } = context.repo;
   const pr = context.payload.pull_request;
@@ -296,8 +362,11 @@ module.exports = async ({ github, context, core }) => {
   const existingComments = await github.paginate(github.rest.pulls.listReviewComments, { owner, repo, pull_number });
   const repliedTo = new Set(existingComments.map(c => c.in_reply_to_id).filter(id => id != null));
 
-  let summaries = 0;
-  let inlineTotal = 0;
+  // 4a. Parse + classify each persona's findings. Accumulate the anchorable
+  //     inline findings across ALL personas (each with a stable id) so the
+  //     orchestrator can dedupe the whole set; keep summary/folded per persona.
+  const perPersona = [];
+  const allInline = [];
   for (const res of results) {
     if (!res) continue;
     const p = res.persona;
@@ -305,17 +374,30 @@ module.exports = async ({ github, context, core }) => {
     const badge = p.image ? `<img src="${p.image}" width="20" align="top" alt="${p.title}">` : p.emoji;
     const inlineMarker = `<!-- council-of-claudes:inline:${p.key} -->`;
     const { summary, findings } = parseFindings(res.review);
-
-    // Split findings into anchorable vs. unanchorable (folded into summary).
     const folded = [];
     const anchorable = [];
-    for (const f of findings) {
-      if (anchors.get(f.file)?.has(f.line)) anchorable.push(f);
-      else folded.push(f);
-    }
+    findings.forEach((f, i) => {
+      if (anchors.get(f.file)?.has(f.line)) {
+        const id = `${p.key}-${i}`;
+        anchorable.push({ id, ...f });
+        allInline.push({ id, persona: p.title, file: f.file, line: f.line, body: f.body });
+      } else {
+        folded.push(f); // no valid line anchor → goes to the summary
+      }
+    });
+    perPersona.push({ p, badge, inlineMarker, summary, folded, anchorable });
+  }
 
-    // 4a. Inline: delete this persona's prior comments that have NO replies
-    //     (preserve any thread with discussion), then post the fresh set.
+  // 4b. Orchestrator: dedupe the combined inline set → ids to drop. Lossless on
+  //     any failure / unconfigured (returns empty → post everything).
+  const drop = await orchestrateDedup({ core, allInline });
+
+  // 4c. Post per persona: delete prior no-reply inline, post surviving inline
+  //     (skipping orchestrator-dropped duplicates), then the sticky summary.
+  let summaries = 0;
+  let inlineTotal = 0;
+  let dropped = 0;
+  for (const { p, badge, inlineMarker, summary, folded, anchorable } of perPersona) {
     const priorInline = existingComments.filter(c => (c.body || '').includes(inlineMarker));
     for (const c of priorInline) {
       if (repliedTo.has(c.id)) continue; // keep — has a discussion thread
@@ -327,6 +409,7 @@ module.exports = async ({ github, context, core }) => {
     }
     let inline = 0;
     for (const f of anchorable) {
+      if (drop.has(f.id)) { dropped++; continue; } // redundant — removed by orchestrator
       const body = `${badge} **${p.title}** — ${f.body}\n\n${inlineMarker}`;
       try {
         await github.rest.pulls.createReviewComment({
@@ -341,8 +424,8 @@ module.exports = async ({ github, context, core }) => {
     }
     inlineTotal += inline;
 
-    // 4b. Summary: sticky review, updated in place. Folded findings (no valid
-    //     line anchor) are listed here so nothing is lost.
+    // Summary: sticky review, updated in place. Folded findings (no valid line
+    // anchor) are listed here so nothing is lost.
     const marker = `<!-- council-of-claudes:${p.key} -->`;
     let body =
       `### ${badge} Council of Claudes — ${p.title}\n\n` +
@@ -368,5 +451,5 @@ module.exports = async ({ github, context, core }) => {
       core.warning(`${p.title}: failed to post/update summary (${safe(e.message)})`);
     }
   }
-  core.info(`Done: ${summaries}/${active.length} summaries, ${inlineTotal} inline comment(s) on PR #${pull_number}`);
+  core.info(`Done: ${summaries}/${active.length} summaries, ${inlineTotal} inline posted, ${dropped} duplicate(s) dropped on PR #${pull_number}`);
 };

--- a/.github/workflows/scripts/orchestrator.md
+++ b/.github/workflows/scripts/orchestrator.md
@@ -14,7 +14,7 @@ You do **not** judge whether a comment is correct, valuable, or nit-picky. You d
 ## Input
 A JSON array of inline review comments, each:
 ```json
-{ "id": "<stable id>", "persona": "<persona name>", "file": "<path>", "line": <number>, "body": "<markdown>" }
+{ "id": "<id — opaque per-request token; echo it back exactly>", "persona": "<persona name>", "file": "<path>", "line": <number>, "body": "<markdown>" }
 ```
 
 ## What counts as a duplicate

--- a/.github/workflows/scripts/orchestrator.md
+++ b/.github/workflows/scripts/orchestrator.md
@@ -1,0 +1,79 @@
+# Review Orchestrator — Council of Claudes
+
+Paste this as the `systemMessage` when creating the **orchestrator** agent in the
+kagent portal (https://agents.tigera.ai). Model: `gpt-5`.
+
+This agent is NOT a code reviewer — it does not read the diff or generate review comments. It is a
+deduplication layer that runs *after* the review personas and decides which of their comments are
+redundant restatements of each other.
+
+---
+
+You are the **deduplication orchestrator** for a multi-agent code-review system. Several independent
+reviewer personas have each left inline comments on one pull request. Personas frequently make the
+**same point** as one another (and sometimes repeat themselves), in different words. Your only job is
+to find those redundant groups so the system can keep one comment per point and drop the rest.
+
+You do **not** judge whether a comment is correct, valuable, or nit-picky. You do **not** rewrite,
+summarize, or generate any comment text. You only group genuine duplicates and pick which one to keep.
+
+## Input
+A JSON array of inline review comments, each:
+```json
+{ "id": "<stable id>", "persona": "<persona name>", "file": "<path>", "line": <number>, "body": "<markdown>" }
+```
+
+## What counts as a duplicate
+Two (or more) comments are duplicates **only when they make essentially the same actionable point** —
+the same underlying issue AND the same suggested fix/direction — even if:
+- worded differently, or
+- authored by different personas (or the same persona twice), or
+- anchored a line or two apart.
+
+These are **NOT** duplicates (keep them separate):
+- Same file / function / topic but **different issues** (e.g. two distinct bugs in one function).
+- A **general** observation vs. a **specific instance** of it.
+- The same kind of issue (e.g. "naming") raised about **different** identifiers/locations.
+- Comments that merely *relate* to each other but ask for different things.
+
+When in doubt, **do not group them** — leave them separate. It is much worse to wrongly merge two
+distinct findings (losing one) than to leave a borderline pair unmerged. Precision over recall.
+
+## Choosing the survivor
+For each duplicate group, choose exactly one **survivor**: the single **clearest, most actionable,
+best-articulated** comment — the one that would most help the PR author understand and fix the issue.
+Choose on clarity/usefulness alone, **regardless of which persona authored it**. The other comments in
+the group are the duplicates to drop.
+
+## Output
+Respond with **only** a JSON object (a fenced ```json block is acceptable), in exactly this shape:
+```json
+{
+  "clusters": [
+    { "survivor": "<id>", "duplicates": ["<id>", "<id>"], "reason": "<one-line gist of the shared point>" }
+  ]
+}
+```
+Rules for the output:
+- Include a cluster **only** if it has at least one duplicate (group size ≥ 2). A comment with no
+  duplicate must **not** appear anywhere in the output — anything you don't mention is kept.
+- Use the **exact** `id` values from the input. Never invent ids or return ids that weren't provided.
+- Each id may appear **at most once** across the whole output (as a survivor or a duplicate, not both,
+  and not in two clusters).
+- Never include comment bodies, rewrites, or any prose outside the JSON object.
+- If there are no duplicates at all, return `{ "clusters": [] }`.
+
+## Example
+Input (abbreviated):
+```json
+[
+  {"id":"a1","persona":"Correctness","file":"x.go","line":42,"body":"This `==` is case-sensitive; use strings.EqualFold or the feature silently disables."},
+  {"id":"b2","persona":"Nell","file":"x.go","line":42,"body":"Comparison is case-sensitive — should this use EqualFold?"},
+  {"id":"c3","persona":"Security","file":"y.go","line":10,"body":"Interval has no lower bound; a tiny value could hammer the dataplane."}
+]
+```
+Output:
+```json
+{ "clusters": [ { "survivor": "a1", "duplicates": ["b2"], "reason": "case-sensitive compare should use EqualFold" } ] }
+```
+(`c3` is unique, so it is absent from the output and will be kept.)

--- a/.github/workflows/scripts/orchestrator.md
+++ b/.github/workflows/scripts/orchestrator.md
@@ -1,7 +1,7 @@
 # Review Orchestrator — Council of Claudes
 
 Paste this as the `systemMessage` when creating the **orchestrator** agent in the
-kagent portal (https://agents.tigera.ai). Model: `gpt-5`.
+kagent portal (https://agents.tigera.ai). Model: `claude-opus-4-8`.
 
 This agent is NOT a code reviewer — it does not read the diff or generate review comments. It is a deduplication layer that runs *after* the review personas and decides which of their comments are redundant restatements of each other.
 

--- a/.github/workflows/scripts/orchestrator.md
+++ b/.github/workflows/scripts/orchestrator.md
@@ -3,19 +3,13 @@
 Paste this as the `systemMessage` when creating the **orchestrator** agent in the
 kagent portal (https://agents.tigera.ai). Model: `gpt-5`.
 
-This agent is NOT a code reviewer — it does not read the diff or generate review comments. It is a
-deduplication layer that runs *after* the review personas and decides which of their comments are
-redundant restatements of each other.
+This agent is NOT a code reviewer — it does not read the diff or generate review comments. It is a deduplication layer that runs *after* the review personas and decides which of their comments are redundant restatements of each other.
 
 ---
 
-You are the **deduplication orchestrator** for a multi-agent code-review system. Several independent
-reviewer personas have each left inline comments on one pull request. Personas frequently make the
-**same point** as one another (and sometimes repeat themselves), in different words. Your only job is
-to find those redundant groups so the system can keep one comment per point and drop the rest.
+You are the **deduplication orchestrator** for a multi-agent code-review system. Several independent reviewer personas have each left inline comments on one pull request. Personas frequently make the **same point** as one another (and sometimes repeat themselves), in different words. Your only job is to find those redundant groups so the system can keep one comment per point and drop the rest.
 
-You do **not** judge whether a comment is correct, valuable, or nit-picky. You do **not** rewrite,
-summarize, or generate any comment text. You only group genuine duplicates and pick which one to keep.
+You do **not** judge whether a comment is correct, valuable, or nit-picky. You do **not** rewrite, summarize, or generate any comment text. You only group genuine duplicates and pick which one to keep.
 
 ## Input
 A JSON array of inline review comments, each:
@@ -24,8 +18,7 @@ A JSON array of inline review comments, each:
 ```
 
 ## What counts as a duplicate
-Two (or more) comments are duplicates **only when they make essentially the same actionable point** —
-the same underlying issue AND the same suggested fix/direction — even if:
+Two (or more) comments are duplicates **only when they make essentially the same actionable point** — the same underlying issue AND the same suggested fix/direction — even if:
 - worded differently, or
 - authored by different personas (or the same persona twice), or
 - anchored a line or two apart.
@@ -36,14 +29,11 @@ These are **NOT** duplicates (keep them separate):
 - The same kind of issue (e.g. "naming") raised about **different** identifiers/locations.
 - Comments that merely *relate* to each other but ask for different things.
 
-When in doubt, **do not group them** — leave them separate. It is much worse to wrongly merge two
-distinct findings (losing one) than to leave a borderline pair unmerged. Precision over recall.
+When in doubt, **do not group them** — leave them separate. It is much worse to wrongly merge two distinct findings (losing one) than to leave a borderline pair unmerged. Precision over recall.
 
 ## Choosing the survivor
-For each duplicate group, choose exactly one **survivor**: the single **clearest, most actionable,
-best-articulated** comment — the one that would most help the PR author understand and fix the issue.
-Choose on clarity/usefulness alone, **regardless of which persona authored it**. The other comments in
-the group are the duplicates to drop.
+For each duplicate group, choose exactly one **survivor**: the single **clearest, most actionable, best-articulated** comment — the one that would most help the PR author understand and fix the issue.
+Choose on clarity/usefulness alone, **regardless of which persona authored it**. The other comments in the group are the duplicates to drop.
 
 ## Output
 Respond with **only** a JSON object (a fenced ```json block is acceptable), in exactly this shape:
@@ -55,11 +45,9 @@ Respond with **only** a JSON object (a fenced ```json block is acceptable), in e
 }
 ```
 Rules for the output:
-- Include a cluster **only** if it has at least one duplicate (group size ≥ 2). A comment with no
-  duplicate must **not** appear anywhere in the output — anything you don't mention is kept.
+- Include a cluster **only** if it has at least one duplicate (group size ≥ 2). A comment with no duplicate must **not** appear anywhere in the output — anything you don't mention is kept.
 - Use the **exact** `id` values from the input. Never invent ids or return ids that weren't provided.
-- Each id may appear **at most once** across the whole output (as a survivor or a duplicate, not both,
-  and not in two clusters).
+- Each id may appear **at most once** across the whole output (as a survivor or a duplicate, not both, and not in two clusters).
 - Never include comment bodies, rewrites, or any prose outside the JSON object.
 - If there are no duplicates at all, return `{ "clusters": [] }`.
 

--- a/hack/council-of-claudes/README.md
+++ b/hack/council-of-claudes/README.md
@@ -7,6 +7,9 @@ The idea: take a real upstream PR that humans reviewed, reproduce **the exact co
 reviewers first saw**, open it as a PR in this fork so the Council reviews it, then compare the
 Council's feedback to the original human review.
 
+**Design:** the orchestrator (cross-persona dedup) layer and the review-quality decisions are
+documented in [`orchestrator-design.md`](./orchestrator-design.md).
+
 ## Tools
 
 ### `gen-benchmark-pr.sh <upstream-PR-number>`

--- a/hack/council-of-claudes/gen-benchmark-pr.sh
+++ b/hack/council-of-claudes/gen-benchmark-pr.sh
@@ -65,8 +65,12 @@ echo "  author: @$author   human top-level review comments: $humans"
 echo "  base  : ${base:0:12}"
 echo "  head  : ${head:0:12}  (earliest human-reviewed commit)"
 
-baseBr="coc-sample-$N-base"
-headBr="coc-sample-$N-head"
+# Optional iteration label (ITER=v2) → parallel duplicate PRs for the same
+# original, so a new run doesn't clobber an earlier labeled baseline. Empty by
+# default (branches stay coc-sample-<N>-base/head).
+SUFFIX="${ITER:+-$ITER}"
+baseBr="coc-sample-$N$SUFFIX-base"
+headBr="coc-sample-$N$SUFFIX-head"
 
 # Resolve the fork point (merge-base) and the as-reviewed diff via the GitHub
 # compare API rather than local git. This works even when the PR was force-pushed
@@ -147,7 +151,7 @@ fi
 
 echo "Opening PR ..."
 gh pr create --repo "$FORK" --base "$baseBr" --head "$headBr" \
-  --title "[sample #$N] $title" \
+  --title "[sample #$N]${ITER:+ [$ITER]} $title" \
   --body "Benchmark sample reproducing the **as-first-reviewed** state of [$UPREPO#$N](https://github.com/$UPREPO/pull/$N) (by @$author).
 
 This PR's diff equals what the human reviewers first saw: fork point \`${fork:0:12}\` → earliest human-reviewed commit \`${head:0:12}\`. The original PR drew **$humans** human top-level review comments — the ground truth to compare the Council's feedback against.

--- a/hack/council-of-claudes/orchestrator-design.md
+++ b/hack/council-of-claudes/orchestrator-design.md
@@ -1,0 +1,282 @@
+# Council of Claudes — Review-Quality & Orchestrator Design
+
+> Design doc for the orchestrator (review-quality pass). Scoped to that work; broader
+> Council history lives in the team's separate working notes.
+> Status: **design complete — all 9 open questions resolved (2026-06-21); implemented in
+> the orchestrator PR.** Created 2026-06-19. See "Resolved design at a glance (v1)" and
+> the Decisions log below.
+
+## Context — why we're doing this
+Team members reviewed the Council's output on real (duplicated) PRs and gave feedback:
+the reviews have **real value**, but two problems hurt signal-to-noise:
+1. **Redundancy** — multiple personas make the same core point in slightly different words.
+2. **Too many low-value / nit-pick comments** — especially Maintainability & Tests, and to a
+   lesser extent the human personas (Nell, Casey).
+
+Decision: do a quality pass on the system **before** moving it upstream to Project Calico and
+deploying for real. Two improvement levers (below): an **orchestrator agent** + **persona prompt
+tweaks**.
+
+## Evidence — ground truth from PRs #218, #200, #201
+We analyzed the Council's comments **and the human reviewers' replies on those threads** (the
+human replies are ground-truth labels for which comments landed).
+
+**Sample-size caveat:** #200 is richly labeled (16 human replies), #218 partial (9), #201 nearly
+silent (3 replies to 38 comments — low engagement is itself a fatigue signal). Conclusions lean on
+#200/#218.
+
+**Per-persona scorecard (human-engaged comments):**
+
+| Persona | Validated 👍 | Rejected 👎 | Neutral | Read |
+|---|---|---|---|---|
+| 🔎 Correctness | 3 | 0 | 0 | 100% hit when engaged — the franchise; protect |
+| 🛡️ Security | 1 | 0 | 0 | valued ("makes the developer think"); protect |
+| 🧪 Maintainability & Tests | 3 | 5 | 1 | only net-negative persona |
+| Nell | 2 | 1 | 2 | mixed |
+| Casey | 3 | 2 | 1 | mixed |
+
+**Key findings:**
+- **Redundancy is the #1 irritant — proven.** On #200 one flaky-timing issue drew ~6 near-identical
+  comments; the reviewer validated the first then tagged the rest *"same as above," "also is
+  duplicate," "feels 3 comments about the same issue."*
+- **Maintainability's test/comment-padding is the worst offender.** Every "add a unit test / add a
+  comment / make it injectable" was declined: *"too many tests is overkill," "don't want to be too
+  verbose," "this is not required," "not an issue."*
+- **Persona fidelity is itself a rejection axis.** Humans rejected Casey/Nell nits with *"I don't
+  think Nell would add such a comment 😄"* / *"I don't think Casey would add this."* → the simulated
+  personas are currently **more nit-picky than their real namesakes**.
+- **Don't blanket-drop nits.** A genuinely useful efficiency nit (Casey: "store `netip.Addr` instead
+  of re-parsing") earned *"good point."* Rejection tracks the **type** (cosmetic / test-padding),
+  not the "nit" label → filter on **value (changes behavior/cost?)**, not on smallness.
+- **No substantive comment was ever rejected.** False-positive risk lives entirely in nits +
+  test/comment padding, not in Correctness/Security.
+- **Volume suppresses engagement.** 38-comment PR → ~0 replies; 17-comment PR → 16 replies. Fewer,
+  deduped, higher-confidence comments → more engagement. Volume reduction is itself a goal.
+
+## Goals
+- Cut redundant + low-value inline volume **roughly in half** while losing **~no substantive
+  findings**.
+- Preserve the multi-voice demo value (distinct personas, incl. Nell/Casey avatars).
+- Keep Correctness/Security untouched (they're clean).
+
+## Lever 1 — Orchestrator agent (the centerpiece; needs design)
+An "intelligence layer" agent that sits in front of / after the individual review agents. Initial
+purpose: **dedupe + value-filter** the combined output. Long-term: a place to add cross-cutting
+review intelligence.
+
+**Where it fits (proposed):** the workflow already fans out to personas in parallel and **collects
+all findings before posting** (`council_of_claudes.js`). Insert the orchestrator between collection
+and posting:
+> fan out → collect all findings → **orchestrator: keep/drop + dedupe** → post survivors, still
+> attributed to their original personas (preserves Nell/Casey voices).
+
+**My recommendations so far (to validate together):**
+- **Conservative:** only remove clear cross-persona duplicates + clear low-value; when unsure, keep.
+- **Value-based nit filter, not label-based** (a good efficiency nit is keepable).
+- **Preserve per-persona attribution:** for a duplicate cluster, keep the single best/highest-authority
+  instance (Correctness/Security own bugs) and drop the rest.
+- **Graceful degradation:** if the orchestrator errors/times out, post everything unfiltered — never
+  lose a review.
+
+**Token/context budget (addresses the "will it fit?" concern):**
+- Per-PR persona comment text ≈ **6–10K tokens** (measured across the 3 PRs).
+- Diff (capped at 100 KB) ≈ **~25K tokens**.
+- gpt-5 context ~200K+; kagent request limit 4 MiB → even **diff + all comments (~35K) fits**.
+- **But the orchestrator likely doesn't need the full diff.** For deduping, the comments carry their
+  own context (`file:line` + finding text). → **Start "comments-only" (~6–10K tokens)**; if it needs
+  code context to judge "misses the mark," feed only the **specific hunks** the comments anchor to.
+
+## Lever 2 — Persona prompt tweaks (companion)
+- **Maintainability & Tests (highest priority):** hard-gate test suggestions — only when the change
+  introduces untested branching/regression-prone logic **not already covered** in this PR; never for
+  mechanical/plumbing changes or FV/E2E-covered paths. Consolidate "duplicated in A and B" into one
+  comment; demote doc/comment asks to the summary.
+- **Nell / Casey:** recalibrate toward their **real namesakes' substance-first style** (the ground
+  truth says they over-nitpick vs. the real people). This revises the earlier "leave them alone, let
+  the orchestrator filter" idea — do both.
+- **Correctness / Security:** leave as-is. Optional **lane discipline** nudge across personas —
+  each reviews through its *own lens* and shouldn't re-raise what's clearly another lens's domain
+  (e.g. a compile error / race is Correctness's lane). This reduces redundancy at the source
+  *without* asserting any persona is "more authoritative" (see vNext — authority is deliberately
+  open).
+
+## Open design questions (agenda for tonight)
+1. **Orchestrator input scope:** comments-only vs. comments + anchored hunks vs. comments + full diff?
+   (Lean toward comments-only to start.)
+2. **Responsibilities:** dedup only, or dedup + value-filter? Does it also re-rank / cap volume?
+3. **Output schema:** how does it return verdicts so the GHA can act deterministically? (e.g. per-comment
+   `keep|drop` + reason, plus dedup groupings with a chosen survivor.)
+4. **Attribution model:** keep survivors under original personas (recommended) vs. a single consolidated
+   "Council" review?
+5. **Where it runs:** a new kagent persona/agent called by the GHA, gated on its own secret (like the others)?
+6. **Failure handling:** confirm "post unfiltered on orchestrator failure."
+7. **How aggressive:** target volume / confidence threshold; risk of over-filtering substantive items.
+8. **Interaction with Lever 2:** how much to fix at the source (prompts) vs. downstream (orchestrator).
+9. **Benchmark:** re-run the 3 sample PRs through the new pipeline and compare to the human ground truth
+   (this is also the seed of the regression-suite idea).
+
+## Guiding principle
+This is a **multi-agent** system, not a monolith. Keep responsibility/control/complexity
+distributed; resist concentrating judgement in any single agent (including the orchestrator).
+A division of labour between agents *is* the architecture — so the orchestrator does one thing
+well rather than becoming a single point of complexity/failure.
+
+## Decisions log
+
+### Q2 — Responsibilities → **dedup only**
+The orchestrator's single job is to eliminate **redundant** comments (cross-persona, and within a
+persona). It does **not** value-judge / nit-filter as a primary responsibility — that stays with
+the individual personas (see Q8). Keeps the orchestrator simple, low-token, low-risk, and avoids a
+single point of complexity. (Open: a *conservative* "drop obvious junk" backstop — TBD, leaning no
+for v1 to keep the job pure.)
+
+### Q8 — Division of labour (source vs. orchestrator) → **strict split**
+- **Orchestrator:** dedup only — the one problem that is *structurally* unfixable at the source
+  (no persona can see the others' output).
+- **Persona prompts (Lever 2):** own everything else — nit/volume reduction by value-judgement
+  (esp. Maintainability & Tests), and Nell/Casey fidelity to their real namesakes' substance-first
+  style. Each persona is improved standalone.
+The orchestrator fixes nothing except redundancy; all other quality control lives in the personas.
+
+### Q5 — Where it runs → **new kagent agent, gated on its own secret**
+A new gpt-5 kagent agent (`ORCHESTRATOR_AGENT_URL` / `_TOKEN`), called from
+`council_of_claudes.js` after all personas return and before posting, using the existing async
+submit+poll pattern. If the secret is unset → skip orchestration and post everything (consistent
+with persona gating). Cost: one extra serial async generation (~1–2 min) at the end.
+Dedup must be **semantic** (same point, different words) → needs an LLM, not fuzzy text matching.
+(Future optimization: a cheap exact-match prefilter in code before the LLM call.)
+
+### Q1 — Input scope → **comments-only; all inline comments from all personas**
+The orchestrator receives a list of findings, each `{id, persona, file, line, body}` — **no diff**
+(dedup needs only the finding text + location). 
+- **(A) Inline comments only for v1**; persona summaries pass through untouched (a summary is a
+  paragraph that can't be partially dropped without rewriting). *Future:* have personas emit
+  summaries as discrete bullet-point sections so the orchestrator can drop whole sections by
+  reference (no rewrite) — same decisions-only principle.
+- **(B) Dedup the entire combined set — cross-persona AND within-persona.** Redundancy is the
+  orchestrator's job regardless of source; within-persona dedup is a safety net in case a persona
+  fails to self-consolidate (Lever 2 still asks personas to self-consolidate; this backstops it).
+
+### Q3 — Output schema → **clusters of duplicates only; omission = keep**
+The orchestrator returns **decisions only, never rewritten comment bodies** (the JS holds the real
+comment objects + persona markers and applies decisions — no rewrite, no hallucination risk):
+```json
+{ "clusters": [ { "survivor": "<id>", "duplicates": ["<id>", ...], "reason": "<one line>" } ] }
+```
+The JS keeps every `survivor`, keeps every id **not mentioned anywhere** (safe default), and drops
+only the listed `duplicates`. Properties: compact (unique findings need zero output); an orchestrator
+omission/partial result degrades to *less dedup*, never a lost finding; defensive JS validation —
+ignore unknown/hallucinated ids, and if an id is both a survivor and a duplicate, **keep wins**.
+
+### Q4 — Survivor selection → **clarity-first, regardless of persona**
+A dedup cluster contains comments making the *same point* (they agree), so survivor selection is
+purely about phrasing, not correctness → **keep the single clearest, most actionable instance**,
+regardless of which persona authored it (best wording = best understanding for the human author).
+The survivor **keeps its original persona identity/avatar/marker** (no merging into a generic
+"Council" voice — preserves the Nell/Casey voices). No authority/pecking-order is used (see vNext).
+
+### Q6 — Failure handling → **graceful degradation (post all)**
+If the orchestrator errors, times out (exceeds the poll window), returns unparseable JSON, **or is
+not configured** (secret unset) → log a warning and **post all comments unfiltered**. The
+orchestrator runs after collection, so the full comment set is always in hand → fallback is trivial
+and lossless. Never lose a review.
+
+### Q7 — Aggressiveness → **conservative clustering, no hard cap**
+- **No hard volume cap** in v1 — dedup + Lever-2 source reductions cut volume organically; a numeric
+  cap reintroduces the risk of dropping a *substantive* comment to hit a number. Measure after the
+  benchmark; add a cap only if still needed.
+- **Tune against over-merging:** cluster only when the underlying issue **and** the suggested fix are
+  essentially the same (same actionable point, different wording / ±a line or two). NOT duplicates:
+  same file/function/topic but different issues; a general point vs. a specific instance. Prompt
+  biases toward **leaving comments separate when unsure** — second safeguard alongside omission=keep.
+
+### Q9 — Benchmark / validation → **fresh duplicate PRs vs. labeled baseline**
+Validate the new pipeline on the 3 sample PRs (#218/#200/#201) by generating **fresh** duplicate
+PRs (new branches, e.g. a `-v2` suffix) so the existing PRs — which carry the old Council comments
+**and the human-reply ground truth** — stay intact as the labeled baseline. Score the new run
+against the existing human labels on three criteria:
+1. **Orchestrator:** the redundant clusters humans complained about collapse to one (e.g. #200
+   flaky-timing 6→1, #218 unused-macro 3→1); no non-duplicate is dropped.
+2. **Lever-2:** comments humans *rejected* shrink (Maintainability "add a test"; Nell/Casey off-
+   persona nits).
+3. **Both:** comments humans *validated* survive (the race, case-sensitivity, int64→int32 truncation).
+
+Generalized methodology (for every future change): **fresh duplicate PRs → compare to a baseline**
+(a prior iteration now; a permanent labeled set eventually). Full regression suite = out of scope
+(tracked separately as future work); this is a lightweight one-time before/after for now.
+
+## Resolved design at a glance (v1)
+End-to-end flow:
+1. Personas (with **Lever-2** prompt tweaks) review the PR in parallel as today → inline comments + summaries.
+2. `council_of_claudes.js` collects all inline comments, assigns each a stable `id`, builds `[{id, persona, file, line, body}]`.
+3. If `ORCHESTRATOR_AGENT_URL/_TOKEN` set → call the orchestrator kagent agent (async submit+poll), **comments-only, no diff**.
+4. Orchestrator returns `{clusters:[{survivor, duplicates[], reason}]}` (dedup only; clarity-first survivor; original persona kept).
+5. JS applies: keep survivors + all unmentioned ids; drop listed duplicates; ignore unknown ids; keep-wins on conflict.
+6. Post surviving inline comments under their original personas; summaries posted as-is (untouched in v1).
+7. **Any** orchestrator failure / unset secret → post everything unfiltered.
+
+Plus **Lever 2** (persona prompts, parallel work): Maintainability test-gating; Nell/Casey fidelity recalibration; cross-persona lane-discipline nudge.
+
+Build order (revised 2026-06-21): ship the two levers as **separate iterations** to isolate
+variables in a human-judged (noisy) evaluation — clean A→B→C progression: *current baseline →
++orchestrator → +Lever-2*, each step independently attributable.
+1. **Orchestrator first** (the heavier change; front-loaded for early team evaluation/buy-in).
+   Cleanly evaluable on its own axis ("did redundancy collapse?"), and stress-tests dedup against
+   the personas' full, un-reduced redundancy.
+2. **Validate** via fresh duplicate PRs vs. the labeled baseline (Q9).
+3. **Then Lever-2** persona tweaks as a second iteration; re-validate against the orchestrator-only baseline.
+
+Team-eval framing for iteration 1: this targets **redundancy only** — nit-noise (Maintainability
+test-padding, Nell/Casey nits) is still present and is the *separate, planned* Lever-2 change. Ask
+reviewers specifically: "are the duplicate comments gone?"
+
+## Evaluation: LLM variance (methodology note)
+The pipeline is stochastic, so two duplicate PRs of the same original (X-1, X-2) on the *same*
+system version will differ. Expected shape: **substantive findings are largely stable** run-to-run;
+**the nit/marginal tail is where variance lives** (and wording always differs → compare
+*semantically*, never exact-text). Accounting for it:
+1. **Measure the noise floor** — run the same version twice (X-1/X-2) as a control to see how big an
+   improvement must be to beat noise.
+2. **Score against stable human labels**, not run-to-run (comparing a stochastic output to a fixed
+   reference is far more robust).
+3. **Lower temperature** for eval runs if the kagent ModelConfig exposes it (cluster-side knob, like
+   model choice) → more reproducible regression runs.
+4. **Average over multiple runs / more PRs.**
+5. **The orchestrator is relatively variance-robust to evaluate** — it dedupes *whatever* the
+   personas emit, so its effect self-normalizes against persona variance. (Persona-prompt tweaks —
+   iteration 2 — are harder: the change and the noise share an axis. Another reason orchestrator-first.)
+These become core requirements of the eventual regression suite.
+
+## Tooling: iteration suffix (DONE — PR #229)
+`gen-benchmark-pr.sh` now takes an optional `ITER` label: `ITER=v2 ./gen-benchmark-pr.sh <N>` →
+`coc-sample-<N>-v2-*` branches + a `[v2]` PR title tag. Lets fresh duplicates coexist with the
+labeled baselines (which key on the unsuffixed `coc-sample-<N>-*`). Empty by default (unchanged).
+
+## Model isolation (decided 2026-06-22)
+The kagent cluster moved environments and now offers more models. To keep the orchestrator's effect
+**cleanly isolated** (the whole reason for shipping it as its own iteration):
+- **Personas stay on `gpt-5`** for this evaluation — matching the labeled baselines (#218/#200/#201),
+  which were generated with gpt-5 personas. So baseline → new-run changes *only* the orchestrator.
+- **Orchestrator runs on `claude-opus-4-8`** — fine, because it's a brand-new component (not a changed
+  variable relative to baseline), and opus suits the semantic dedup judgement. Only `orchestrator.md`
+  carries the opus model ref; the 5 persona docs stay `gpt-5`.
+- **Persona model upgrade (gpt-5 → claude-opus-4-8) becomes its own future iteration**, measured
+  separately (flip the persona docs then). Same variable-isolation discipline.
+
+## Evaluation method (orchestrator iteration)
+- **Primary — the orchestrator's own keep/drop decisions** (variance-immune, no model confound): from
+  the Actions log (`keep X, drop [Y,Z] — reason`), judge precision (were dropped comments genuine
+  duplicates of the survivor?), the failure mode (did any non-duplicate get dropped?), and recall
+  (obvious duplicates it missed?).
+- **Secondary — gpt-5-matched baseline cross-check:** since personas match the baselines' model, verify
+  the *specific* duplicate complaints humans made (e.g. #200 flaky-timing "same as above" ×5) collapse.
+
+## vNext / out of scope (revisit later)
+- **Persona authority hierarchy / agents reviewing or debating each other's comments.** Considered
+  and deliberately deferred: adds a layer of complexity and unclear value to the human author.
+  Authority is irrelevant to dedup (a cluster already agrees); it would only matter for
+  *conflicting-judgment* resolution. Concrete-but-informal observation for now: Correctness &
+  Security have empirically produced the most reliable/actionable comments — but we are **not**
+  encoding any formal precedence in v1.
+- **Summary-review dedup** via structured bullet-point sections (see Q1-A).
+- **Exact-match prefilter in code** before the LLM dedup call (Q5 optimization).


### PR DESCRIPTION
## What
Adds the **orchestrator** — an intelligence layer between persona fan-out and posting that removes **redundant inline comments** (multiple personas making the same point), the #1 reviewer complaint from team feedback.

Per the design (`orchestrator-design.md`), it does **one thing — dedup**. All other quality control (nit/volume reduction) stays with the individual personas as a separate future iteration. This keeps the orchestrator simple and avoids a single point of complexity, consistent with the multi-agent philosophy.

## How it works
1. Personas review in parallel as today → inline comments + summaries.
2. The script collects **all** personas' anchorable inline findings, each with a stable id, as `{id, persona, file, line, body}` (**comments-only — no diff**).
3. The orchestrator (new kagent agent, async submit+poll) returns `{clusters:[{survivor, duplicates, reason}]}` — **decisions only, never rewrites bodies**.
4. The script drops only the flagged duplicates; survivors post under their **original personas** (Nell/Casey voices preserved).

## Safety (lossless by construction)
- **omission = keep** (anything unmentioned is kept), **keep-wins** on conflict, **unknown ids ignored**.
- **Any** failure / timeout / unparseable response / **unset secret** → post everything unfiltered. Never lose a review.
- **Gated on its secret** → this PR is a **no-op until** the orchestrator agent + secrets exist.

## To activate
1. Create the orchestrator agent on kagent with `scripts/orchestrator.md` (model `gpt-5`).
2. Add `ORCHESTRATOR_AGENT_URL` / `ORCHESTRATOR_AGENT_TOKEN` secrets.

## Validation
Mock-tested: dedup (incl. fenced-JSON parsing), graceful degradation (unconfigured + garbage response), keep-wins, and unknown-id handling — all pass. End-to-end validation will be a **fresh duplicate PR** vs. the labeled baselines (#218/#200/#201), checking that the redundant clusters humans flagged collapse.

> Note: this iteration targets **redundancy only**. Nit-noise (Maintainability test-padding, Nell/Casey nits) is unchanged and is the separate, planned Lever-2 change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)