### PR TITLE
cherry-pick-candidate: send labels and changed file paths to classifier

### DIFF
--- a/.github/workflows/scripts/cherry_pick_candidate.js
+++ b/.github/workflows/scripts/cherry_pick_candidate.js
@@ -96,7 +96,23 @@ module.exports = async ({ github, context, core }) => {
   const present = pr.labels.some(l => l.name === LABEL);
   core.info(`Label authority: bot (last actor: ${lastActor || 'none'}, present=${present})`);
 
-  // 3. Call the classifier agent. Up to 3 attempts with 5s, 10s backoff.
+  // 3. Gather extra context for the classifier: existing labels and
+  //    changed file paths. Both are stronger signals than parsing the
+  //    body alone (labels are deliberate human classifications, paths
+  //    reveal whether the change touches production code or only CI /
+  //    tests / docs). Filter out the bot's own label so the agent's
+  //    verdict is not influenced by a prior classification round.
+  const labels = (pr.labels || []).map(l => l.name).filter(n => n !== LABEL);
+  const filesResp = await github.rest.pulls.listFiles({
+    owner, repo, pull_number: pr.number, per_page: 100,
+  });
+  const changedFiles = filesResp.data.map(f => f.filename);
+  const labelsText = labels.length === 0 ? '(none)' : labels.join(', ');
+  const filesText = changedFiles.length === 0
+    ? '(none)'
+    : changedFiles.map(p => `- ${p}`).join('\n');
+
+  // 4. Call the classifier agent. Up to 3 attempts with 5s, 10s backoff.
   const msgId = `calico-backport-classifier-${pr.number}-${process.env.GITHUB_RUN_ID}`;
   const payload = {
     jsonrpc: '2.0',
@@ -108,7 +124,7 @@ module.exports = async ({ github, context, core }) => {
         role: 'user',
         parts: [{
           kind: 'text',
-          text: `PR number: ${pr.number}\nPR title: ${pr.title}\nPR body:\n${pr.body || ''}`,
+          text: `PR number: ${pr.number}\nPR title: ${pr.title}\nPR body:\n${pr.body || ''}\n\nLabels: ${labelsText}\nChanged files:\n${filesText}`,
         }],
       },
       configuration: { acceptedOutputModes: ['application/json', 'text/plain'] },


### PR DESCRIPTION
## Summary

The agent prompt was recently extended to recognise labels (`kind/bug`, `kind/feature`, `skip-bot-cherry-pick`, `release-note-not-required`, etc.) and changed file paths (production code vs tests / CI / docs) as primary signals. Wire the workflow up to actually send those fields so the new prompt has something to work with.

## Diff

`+18 / -2` in `cherry_pick_candidate.js`. No YAML, no permission, no API changes.

- Labels: pulled from the existing `pr` object. Filter out the bot's own `cherry-pick-candidate` label so the agent's verdict is not biased by a prior classification round.
- Changed files: one `pulls.listFiles` call, `per_page: 100`. That cap is enough to identify what kind of change this is in essentially every real PR — any rule like "all paths under X" is still correct on the truncated view in practice.

Both fields are appended to the existing title-and-body text payload. No schema change on either side.

## Example payload after this change

```
PR number: 13014
PR title: Set CNI installMode to CalicoOnly for Windows FV
PR body:
<body>

Labels: docs-not-required, release-note-not-required
Changed files:
- node/Makefile
- ...
```

Under the updated prompt, this would now classify as **skip** based on the `release-note-not-required` label plus the file path pattern (test/build infrastructure), without relying on the body's bug-fix wording.

## Test plan after merge

- [ ] The three Casey-mirror PRs (#230, #231, #232) — re-trigger by editing the title and confirm the new prompt classifies #230 as backport, #231 and #232 as skip.
- [ ] Sample one workflow log and confirm the agent payload includes the new `Labels:` and `Changed files:` lines.

Once green here, push the same patch to `projectcalico/calico`.