### PR TITLE
cherry-pick-candidate: prefix changed paths with [status]

### DIFF
--- a/.github/workflows/scripts/cherry_pick_candidate.js
+++ b/.github/workflows/scripts/cherry_pick_candidate.js
@@ -106,11 +106,18 @@ module.exports = async ({ github, context, core }) => {
   const filesResp = await github.rest.pulls.listFiles({
     owner, repo, pull_number: pr.number, per_page: 100,
   });
-  const changedFiles = filesResp.data.map(f => f.filename);
   const labelsText = labels.length === 0 ? '(none)' : labels.join(', ');
-  const filesText = changedFiles.length === 0
+  // Each entry is "- [status] path" where status is added / removed /
+  // modified / renamed / copied. Status disambiguates new API surface
+  // (`[added] api/**/*types.go`) from API bug fixes (`[modified]` only).
+  const filesText = filesResp.data.length === 0
     ? '(none)'
-    : changedFiles.map(p => `- ${p}`).join('\n');
+    : filesResp.data.map(f => {
+        const base = `- [${f.status}] ${f.filename}`;
+        return f.status === 'renamed' && f.previous_filename
+          ? `${base} (was ${f.previous_filename})`
+          : base;
+      }).join('\n');
 
   // 4. Call the classifier agent. Up to 3 attempts with 5s, 10s backoff.
   const msgId = `calico-backport-classifier-${pr.number}-${process.env.GITHUB_RUN_ID}`;

--- a/.github/workflows/scripts/cherry_pick_candidate.js
+++ b/.github/workflows/scripts/cherry_pick_candidate.js
@@ -103,7 +103,11 @@ module.exports = async ({ github, context, core }) => {
   //    tests / docs). Filter out the bot's own label so the agent's
   //    verdict is not influenced by a prior classification round.
   const labels = (pr.labels || []).map(l => l.name).filter(n => n !== LABEL);
-  const filesResp = await github.rest.pulls.listFiles({
+  // Paginate so big PRs (the monorepo regularly has changes touching
+  // 100+ files) don't get silently truncated to the first page, which
+  // would bias the classifier or let a fork-PR pad with unrelated
+  // paths past the page boundary.
+  const files = await github.paginate(github.rest.pulls.listFiles, {
     owner, repo, pull_number: pr.number, per_page: 100,
   });
   const labelsText = labels.length === 0 ? '(none)' : labels.join(', ');
@@ -112,14 +116,13 @@ module.exports = async ({ github, context, core }) => {
   // and deleted. Status + size lets the classifier separate new API
   // surface (`[added +N]` on api types) from small API fixes
   // (`[modified +2/-1]`), and small defensive tweaks from substantial
-  // rewrites.
-  const filesText = filesResp.data.length === 0
+  // rewrites. previous_filename shows on any status that carries it
+  // (typically renamed, sometimes copied).
+  const filesText = files.length === 0
     ? '(none)'
-    : filesResp.data.map(f => {
+    : files.map(f => {
         const base = `- [${f.status} +${f.additions}/-${f.deletions}] ${f.filename}`;
-        return f.status === 'renamed' && f.previous_filename
-          ? `${base} (was ${f.previous_filename})`
-          : base;
+        return f.previous_filename ? `${base} (was ${f.previous_filename})` : base;
       }).join('\n');
 
   // 4. Call the classifier agent. Up to 3 attempts with 5s, 10s backoff.

--- a/.github/workflows/scripts/cherry_pick_candidate.js
+++ b/.github/workflows/scripts/cherry_pick_candidate.js
@@ -107,13 +107,16 @@ module.exports = async ({ github, context, core }) => {
     owner, repo, pull_number: pr.number, per_page: 100,
   });
   const labelsText = labels.length === 0 ? '(none)' : labels.join(', ');
-  // Each entry is "- [status] path" where status is added / removed /
-  // modified / renamed / copied. Status disambiguates new API surface
-  // (`[added] api/**/*types.go`) from API bug fixes (`[modified]` only).
+  // Each entry is "- [status +A/-D] path" where status is added /
+  // removed / modified / renamed / copied and +A/-D are lines added
+  // and deleted. Status + size lets the classifier separate new API
+  // surface (`[added +N]` on api types) from small API fixes
+  // (`[modified +2/-1]`), and small defensive tweaks from substantial
+  // rewrites.
   const filesText = filesResp.data.length === 0
     ? '(none)'
     : filesResp.data.map(f => {
-        const base = `- [${f.status}] ${f.filename}`;
+        const base = `- [${f.status} +${f.additions}/-${f.deletions}] ${f.filename}`;
         return f.status === 'renamed' && f.previous_filename
           ? `${base} (was ${f.previous_filename})`
           : base;


### PR DESCRIPTION
## Summary

GitHub's `pulls.listFiles` response carries a `status` per file (`added`, `removed`, `modified`, `renamed`, `copied`). The previous payload dropped it. Include it as a prefix on each entry so the classifier can distinguish e.g. new API surface (`[added] api/**/*types.go`) from API bug fixes (`[modified]` only).

Mirror of the second commit on the parallel OSS PR.

## Payload shape

```
Changed files:
- [added] api/pkg/apis/projectcalico/v3/bgpfilter_types.go
- [modified] felix/calc/calc_graph.go
- [removed] hack/old-script.sh
- [renamed] felix/new.go (was felix/old.go)
```

## Cost

Tiny — same single `pulls.listFiles` call, no extra API. Around 10 extra characters per file in the prompt.

## Test plan

- [ ] Merge.
- [ ] Open a same-repo PR that is purely `[added]` API files; confirm the agent classifies it as **skip** with high confidence.
- [ ] Open a same-repo PR that is purely `[modified]` production code in `felix/`; confirm the agent classifies as **backport** when bug-fix language is present.
- [ ] Sample one workflow log and confirm the payload now contains `[status]` prefixes.