### PR TITLE
Orchestrator hang: fresh-task retry + richer error diagnostics

### DIFF
--- a/.github/workflows/scripts/council_of_claudes.js
+++ b/.github/workflows/scripts/council_of_claudes.js
@@ -327,23 +327,31 @@ async function orchestrateDedup({ core, allInline }) {
       `Here are ${allInline.length} inline review comments from one pull request, as a JSON array. ` +
       `Identify redundant duplicate groups and return the clusters JSON per your instructions.\n\n${payload}`;
 
-    // Up to ORCH_ATTEMPTS, each a *fresh* task (distinct msgId), bounded by
-    // ORCH_POLL_MS — so a task that hangs server-side gets a second shot.
-    let out = null;
-    for (let attempt = 1; attempt <= ORCH_ATTEMPTS && !out; attempt++) {
-      const msgId = `council-orchestrator-${process.env.GITHUB_RUN_ID}-${attempt}`;
-      out = await reviewWithAgent({
+    // Up to ORCH_ATTEMPTS, each a *fresh* task bounded by ORCH_POLL_MS — so a
+    // task that hangs server-side OR returns garbled output gets a second shot.
+    const runKey = `${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT || '1'}`;
+    for (let attempt = 1; attempt <= ORCH_ATTEMPTS; attempt++) {
+      // RUN_ATTEMPT + per-attempt suffix → a distinct msgId (hence a fresh
+      // server-side task) on every submission, including GitHub "Re-run" re-runs.
+      const msgId = `council-orchestrator-${runKey}-${attempt}`;
+      const out = await reviewWithAgent({
         core, title: `Orchestrator (attempt ${attempt}/${ORCH_ATTEMPTS})`,
         url, token, messageText, msgId, maxPollMs: ORCH_POLL_MS,
       });
-      if (!out && attempt < ORCH_ATTEMPTS) {
-        core.warning(`Orchestrator: attempt ${attempt} produced no response — resubmitting a fresh task`);
+      const last = attempt === ORCH_ATTEMPTS;
+      if (!out) {
+        if (!last) core.info('Orchestrator: no response — resubmitting a fresh task');
+        continue;
       }
+      const parsed = parseClusters(out);
+      if (!parsed) {
+        if (!last) core.info('Orchestrator: unparseable response — resubmitting a fresh task');
+        continue;
+      }
+      return applyClusters({ core, allInline, parsed });
     }
-    if (!out) { core.warning('Orchestrator: no response after retries — posting all comments unfiltered'); return empty; }
-    const parsed = parseClusters(out);
-    if (!parsed) { core.warning('Orchestrator: unparseable response — posting all comments unfiltered'); return empty; }
-    return applyClusters({ core, allInline, parsed });
+    core.warning('Orchestrator: no usable response after retries — posting all comments unfiltered');
+    return empty;
   } catch (e) {
     core.warning(`Orchestrator: unexpected error (${safe(errDetail(e))}) — posting all comments unfiltered`);
     return empty;
@@ -408,7 +416,9 @@ module.exports = async ({ github, context, core }) => {
   // 3. Fan out to all configured personas in parallel; isolate failures.
   core.info(`Reviewing PR #${pull_number} with ${active.length} persona(s): ${active.map(p => p.title).join(', ')}`);
   const results = await Promise.all(active.map(async p => {
-    const msgId = `council-${p.key}-${pull_number}-${process.env.GITHUB_RUN_ID}`;
+    // Include RUN_ATTEMPT so a GitHub "Re-run" gets a fresh server-side task (the
+    // run id alone is stable across re-runs and could return a stale cached task).
+    const msgId = `council-${p.key}-${pull_number}-${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT || '1'}`;
     const review = await reviewWithAgent({ core, title: p.title, url: p.url, token: p.token, messageText, msgId });
     if (!review) {
       core.warning(`${p.title}: no review produced, skipping`);

--- a/.github/workflows/scripts/council_of_claudes.js
+++ b/.github/workflows/scripts/council_of_claudes.js
@@ -177,8 +177,10 @@ function extractText(task) {
 }
 
 // Submit the review asynchronously and poll to completion. Returns the
-// persona's markdown review, or null on failure.
-async function reviewWithAgent({ core, title, url, token, messageText, msgId }) {
+// persona's markdown review, or null on failure. `maxPollMs` bounds the poll
+// window (defaults to MAX_POLL_MS; the orchestrator passes a shorter per-attempt
+// budget so it can afford a fresh-task retry within the job timeout).
+async function reviewWithAgent({ core, title, url, token, messageText, msgId, maxPollMs = MAX_POLL_MS }) {
   let taskId = null;
   for (let attempt = 1; attempt <= 3; attempt++) {
     try {
@@ -200,7 +202,7 @@ async function reviewWithAgent({ core, title, url, token, messageText, msgId }) 
   if (!taskId) return null;
 
   const start = Date.now();
-  while (Date.now() - start < MAX_POLL_MS) {
+  while (Date.now() - start < maxPollMs) {
     await sleep(POLL_INTERVAL_MS);
     let task;
     try {
@@ -217,13 +219,20 @@ async function reviewWithAgent({ core, title, url, token, messageText, msgId }) 
       return null;
     }
   }
-  core.warning(`${title}: task did not complete within ${MAX_POLL_MS / 1000}s`);
+  core.warning(`${title}: task did not complete within ${maxPollMs / 1000}s`);
   return null;
 }
 
 // --- Orchestrator: cross-persona deduplication of inline comments ---
 const ORCH_URL_ENV = 'ORCHESTRATOR_AGENT_URL';
 const ORCH_TOKEN_ENV = 'ORCHESTRATOR_AGENT_TOKEN';
+// A healthy orchestrator dedups in ~2-3 min; a much longer poll means the task
+// is stuck server-side, not slow. So bound each attempt and resubmit a *fresh*
+// task once — a stuck task usually doesn't recur on a new submission. Two
+// attempts at this budget still fit comfortably inside the 30m job timeout
+// (alongside the persona phase + posting).
+const ORCH_ATTEMPTS = 2;
+const ORCH_POLL_MS = 7 * 60 * 1000;
 
 // Robustly extract the orchestrator's { clusters: [...] } JSON from its response
 // (tolerates a ```json fence — single- or multi-line — or stray prose). Returns
@@ -287,15 +296,26 @@ async function orchestrateDedup({ core, allInline }) {
   if (allInline.length < 2) return empty; // nothing to dedupe (need ≥2 comments)
 
   try {
-    const msgId = `council-orchestrator-${process.env.GITHUB_RUN_ID}`;
     const payload = JSON.stringify(allInline.map(c =>
       ({ id: c.id, persona: c.persona, file: c.file, line: c.line, body: c.body })));
     const messageText =
       `Here are ${allInline.length} inline review comments from one pull request, as a JSON array. ` +
       `Identify redundant duplicate groups and return the clusters JSON per your instructions.\n\n${payload}`;
 
-    const out = await reviewWithAgent({ core, title: 'Orchestrator', url, token, messageText, msgId });
-    if (!out) { core.warning('Orchestrator: no response — posting all comments unfiltered'); return empty; }
+    // Up to ORCH_ATTEMPTS, each a *fresh* task (distinct msgId), bounded by
+    // ORCH_POLL_MS — so a task that hangs server-side gets a second shot.
+    let out = null;
+    for (let attempt = 1; attempt <= ORCH_ATTEMPTS && !out; attempt++) {
+      const msgId = `council-orchestrator-${process.env.GITHUB_RUN_ID}-${attempt}`;
+      out = await reviewWithAgent({
+        core, title: `Orchestrator (attempt ${attempt}/${ORCH_ATTEMPTS})`,
+        url, token, messageText, msgId, maxPollMs: ORCH_POLL_MS,
+      });
+      if (!out && attempt < ORCH_ATTEMPTS) {
+        core.warning(`Orchestrator: attempt ${attempt} produced no response — resubmitting a fresh task`);
+      }
+    }
+    if (!out) { core.warning('Orchestrator: no response after retries — posting all comments unfiltered'); return empty; }
     const parsed = parseClusters(out);
     if (!parsed) { core.warning('Orchestrator: unparseable response — posting all comments unfiltered'); return empty; }
     return applyClusters({ core, allInline, parsed });

--- a/.github/workflows/scripts/council_of_claudes.js
+++ b/.github/workflows/scripts/council_of_claudes.js
@@ -91,6 +91,15 @@ const sleep = ms => new Promise(res => setTimeout(res, ms));
 // ::workflow-command:: strings into the Actions log.
 const safe = s => String(s ?? '').replace(/::/g, ':​:');
 
+// Node's fetch (undici) surfaces generic messages like "fetch failed" /
+// "terminated" and puts the actual reason (ECONNRESET, UND_ERR_*, etc.) on
+// e.cause. Surface both so error logs are diagnosable.
+function errDetail(e) {
+  const c = e?.cause;
+  const cause = c ? ` | cause: ${c.code || c.message || c}` : '';
+  return `${e?.message || e}${cause}`;
+}
+
 // Strip a single markdown fence that wraps the *entire* response, while
 // leaving any inner code/suggestion fences intact.
 function stripOuterFence(text) {
@@ -161,7 +170,13 @@ async function rpc(url, token, body) {
     body: JSON.stringify(body),
     signal: AbortSignal.timeout(RPC_TIMEOUT_MS),
   });
-  if (!r.ok) throw new Error(`http ${r.status}`);
+  if (!r.ok) {
+    // Include statusText and a short body snippet — a 5xx from the gateway often
+    // carries a reason (e.g. upstream timeout) that the bare status code hides.
+    let snippet = '';
+    try { snippet = (await r.text()).replace(/\s+/g, ' ').trim().slice(0, 200); } catch { /* ignore */ }
+    throw new Error(`http ${r.status} ${r.statusText}${snippet ? ` — ${snippet}` : ''}`);
+  }
   const json = await r.json();
   if (json.error) {
     throw new Error(`json-rpc error ${json.error.code ?? '?'}: ${json.error.message ?? 'unknown'}`);
@@ -195,31 +210,41 @@ async function reviewWithAgent({ core, title, url, token, messageText, msgId, ma
       if (taskId) break;
       core.info(`  ${title}: submit returned no task id (attempt ${attempt})`);
     } catch (e) {
-      core.info(`  ${title}: submit attempt ${attempt} failed (${safe(e.message)})`);
+      core.info(`  ${title}: submit attempt ${attempt} failed (${safe(errDetail(e))})`);
     }
     if (attempt < 3) await sleep(attempt * 5000);
   }
-  if (!taskId) return null;
+  if (!taskId) {
+    core.warning(`${title}: could not submit a task after 3 attempts`);
+    return null;
+  }
 
+  // Track poll outcomes so a timeout is diagnosable: a stuck task shows a
+  // non-terminal last state with healthy polls; a network problem shows poll errors.
   const start = Date.now();
+  let polls = 0, pollErrs = 0, lastState = 'none';
   while (Date.now() - start < maxPollMs) {
     await sleep(POLL_INTERVAL_MS);
     let task;
     try {
       const g = await rpc(url, token, { jsonrpc: '2.0', id: `${msgId}-get`, method: 'tasks/get', params: { id: taskId } });
       task = g.result;
+      polls++;
     } catch (e) {
-      core.info(`  ${title}: poll error (${safe(e.message)}), will retry`);
+      pollErrs++;
+      core.info(`  ${title}: poll error (${safe(errDetail(e))}), will retry`);
       continue;
     }
     const state = task?.status?.state;
+    if (state) lastState = state;
     if (state === 'completed') return stripOuterFence(extractText(task));
     if (state === 'failed' || state === 'canceled' || state === 'rejected') {
       core.warning(`${title}: task ${state}`);
       return null;
     }
   }
-  core.warning(`${title}: task did not complete within ${maxPollMs / 1000}s`);
+  core.warning(`${title}: task did not complete within ${maxPollMs / 1000}s ` +
+    `(last state: ${lastState}, ${polls} polls ok, ${pollErrs} poll errors)`);
   return null;
 }
 
@@ -320,7 +345,7 @@ async function orchestrateDedup({ core, allInline }) {
     if (!parsed) { core.warning('Orchestrator: unparseable response — posting all comments unfiltered'); return empty; }
     return applyClusters({ core, allInline, parsed });
   } catch (e) {
-    core.warning(`Orchestrator: unexpected error (${safe(e.message)}) — posting all comments unfiltered`);
+    core.warning(`Orchestrator: unexpected error (${safe(errDetail(e))}) — posting all comments unfiltered`);
     return empty;
   }
 }
@@ -447,7 +472,7 @@ module.exports = async ({ github, context, core }) => {
       try {
         await github.rest.pulls.deleteReviewComment({ owner, repo, comment_id: c.id });
       } catch (e) {
-        core.info(`  ${p.title}: could not delete inline #${c.id} (${safe(e.message)})`);
+        core.info(`  ${p.title}: could not delete inline #${c.id} (${safe(errDetail(e))})`);
       }
     }
     let inline = 0;
@@ -461,7 +486,7 @@ module.exports = async ({ github, context, core }) => {
         inline++;
       } catch (e) {
         // Line wasn't commentable after all — fold it into the summary so it isn't lost.
-        core.info(`  ${p.title}: inline anchor failed at ${safe(f.file)}:${f.line} (${safe(e.message)}), folding into summary`);
+        core.info(`  ${p.title}: inline anchor failed at ${safe(f.file)}:${f.line} (${safe(errDetail(e))}), folding into summary`);
         folded.push(f);
       }
     }
@@ -491,7 +516,7 @@ module.exports = async ({ github, context, core }) => {
       }
       summaries++;
     } catch (e) {
-      core.warning(`${p.title}: failed to post/update summary (${safe(e.message)})`);
+      core.warning(`${p.title}: failed to post/update summary (${safe(errDetail(e))})`);
     }
   }
   core.info(`Done: ${summaries}/${active.length} summaries, ${inlineTotal} inline posted, ${dropped} duplicate(s) dropped on PR #${pull_number}`);


### PR DESCRIPTION
## What
Adds a fresh-task retry to the orchestrator so a server-side **stuck task** gets a second shot instead of degrading straight to post-all.

## Why
On the benchmark runs, #240 (calico#12960) hung the orchestrator at its poll cap **twice** — yet its input was the *smallest* of the three (25 comments vs #241's 42, which completed in ~2.5 min). So it's **not payload size** — it's a task getting stuck server-side. A healthy orchestrator dedups in ~2–3 min, so a long poll means *stuck, not slow*.

## How
- `reviewWithAgent` gains a `maxPollMs` param (defaults to `MAX_POLL_MS`; personas unchanged).
- `orchestrateDedup` makes up to **`ORCH_ATTEMPTS` (2)** attempts, each a **fresh task** (distinct `msgId`) bounded by **`ORCH_POLL_MS` (7 min)** — a fresh submission usually doesn't reproduce a hang. Two 7-min attempts fit comfortably inside the 30-min job timeout alongside the persona phase + posting.
- Still **lossless**: if all attempts produce nothing, post everything unfiltered (graceful degradation preserved).

## Validated
Mock-tested: no-retry-needed, attempt-1-fails→retry-succeeds→dedup-applied, and both-fail→graceful-post-all — all pass.

> Note: if a task is *systematically* stuck on a given input (vs. transiently), the retry won't fix it — that's a kagent-side investigation. This just recovers the common transient-hang case automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)