### PR TITLE
Orchestrator: treat input-required as terminal (fix the hang)

### DIFF
--- a/.github/workflows/scripts/council_of_claudes.js
+++ b/.github/workflows/scripts/council_of_claudes.js
@@ -242,6 +242,14 @@ async function reviewWithAgent({ core, title, url, token, messageText, msgId, ma
       core.warning(`${title}: task ${state}`);
       return null;
     }
+    if (state === 'input-required' || state === 'auth-required') {
+      // The agent is awaiting client follow-up we never send (fire-and-forget),
+      // so this task will never progress. Abandon now (return null) so the caller
+      // can resubmit a fresh task instead of polling the full budget. This is the
+      // root cause behind the earlier orchestrator "hangs".
+      core.warning(`${title}: task ${state} (agent awaiting client input we don't provide) — abandoning`);
+      return null;
+    }
   }
   core.warning(`${title}: task did not complete within ${maxPollMs / 1000}s ` +
     `(last state: ${lastState}, ${polls} polls ok, ${pollErrs} poll errors)`);

--- a/.github/workflows/scripts/council_of_claudes.js
+++ b/.github/workflows/scripts/council_of_claudes.js
@@ -235,19 +235,25 @@ async function reviewWithAgent({ core, title, url, token, messageText, msgId, ma
       core.info(`  ${title}: poll error (${safe(errDetail(e))}), will retry`);
       continue;
     }
-    const state = task?.status?.state;
+    // Normalize so we're robust to casing / underscore variants from the runtime
+    // (A2A uses hyphenated lowercase, e.g. "input-required").
+    const state = (task?.status?.state || '').toLowerCase().replace(/_/g, '-');
     if (state) lastState = state;
     if (state === 'completed') return stripOuterFence(extractText(task));
+    // Terminal failure states: the task won't produce a result.
     if (state === 'failed' || state === 'canceled' || state === 'rejected') {
       core.warning(`${title}: task ${state}`);
       return null;
     }
+    // Interrupted states: the agent is waiting for a client follow-up we never
+    // send (fire-and-forget), so the task can't progress. Abandon now (return
+    // null) so the caller can resubmit a fresh task instead of polling the full
+    // budget. (Root cause behind the earlier orchestrator "hangs".)
     if (state === 'input-required' || state === 'auth-required') {
-      // The agent is awaiting client follow-up we never send (fire-and-forget),
-      // so this task will never progress. Abandon now (return null) so the caller
-      // can resubmit a fresh task instead of polling the full budget. This is the
-      // root cause behind the earlier orchestrator "hangs".
-      core.warning(`${title}: task ${state} (agent awaiting client input we don't provide) — abandoning`);
+      const why = state === 'auth-required'
+        ? 'authentication problem; check the agent token/credentials'
+        : 'agent awaiting client input we never send';
+      core.warning(`${title}: task ${state} (${why}); abandoning early`);
       return null;
     }
   }

--- a/.github/workflows/scripts/orchestrator.md
+++ b/.github/workflows/scripts/orchestrator.md
@@ -50,6 +50,9 @@ Rules for the output:
 - Each id may appear **at most once** across the whole output (as a survivor or a duplicate, not both, and not in two clusters).
 - Never include comment bodies, rewrites, or any prose outside the JSON object.
 - If there are no duplicates at all, return `{ "clusters": [] }`.
+- **Never ask for clarification or request more input** — you already have everything you need.
+  Always respond with the JSON object and nothing else; if you are unsure, return
+  `{ "clusters": [] }` rather than a question.
 
 ## Example
 Input (abbreviated):

--- a/.github/workflows/scripts/orchestrator.md
+++ b/.github/workflows/scripts/orchestrator.md
@@ -50,9 +50,8 @@ Rules for the output:
 - Each id may appear **at most once** across the whole output (as a survivor or a duplicate, not both, and not in two clusters).
 - Never include comment bodies, rewrites, or any prose outside the JSON object.
 - If there are no duplicates at all, return `{ "clusters": [] }`.
-- **Never ask for clarification or request more input** — you already have everything you need.
-  Always respond with the JSON object and nothing else; if you are unsure, return
-  `{ "clusters": [] }` rather than a question.
+- **Never ask for clarification or request more input** — always respond with the JSON object and
+  nothing else. If unsure, return `{ "clusters": [] }`.
 
 ## Example
 Input (abbreviated):


### PR DESCRIPTION
## What
Fixes the root cause of the orchestrator "hangs" (e.g. the #240/#241 timeouts).

## Root cause (grounded)
The new poll diagnostics surfaced it: `task did not complete within 420s (last state: input-required, 82 polls ok, 0 poll errors)`. The orchestrator task occasionally lands in the A2A **`input-required`** state — the agent asks for a follow-up instead of returning the clusters JSON. A2A task states come from the kagent runtime (`agents-menagerie` just *proxies* via `ProxyA2A` — confirmed by reading its source). In our **fire-and-forget** usage we never send the follow-up, so the task can never progress — our poll loop only treated `completed/failed/canceled/rejected` as terminal, so it polled the full budget then gave up. Non-determinism is sampling variance, not input-specific.

## Fix
- **`reviewWithAgent`:** treat `input-required` / `auth-required` as terminal — abandon immediately (return null) so the caller's fresh-task retry fires in **seconds** instead of after the full budget. (Mock: abandons after ~one poll vs the 7-min `ORCH_POLL_MS`.)
- **`orchestrator.md`:** instruct the agent to **never ask for clarification** — always return the JSON (`{"clusters":[]}` if unsure) — reducing the occurrence at the source.

Still **lossless**: if all attempts abandon, post everything unfiltered.

## Validated
Mock tests: input-required & auth-required abandon fast and the retry recovers (dedup applied); both-attempts-fail → graceful post-all. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)