### PR TITLE
Council test harness: node:test unit tests + CI (calico-oss-test only)

### DIFF
--- a/.github/workflows/council-tests.yml
+++ b/.github/workflows/council-tests.yml
@@ -1,0 +1,27 @@
+# Council of Claudes — unit tests for the review logic (council_of_claudes.js).
+#
+# calico-oss-test ONLY. This guards the Council logic during development in this
+# fork; it is deliberately NOT cherry-picked upstream. The Council *product* (the
+# review workflow + persona prompts + orchestrator) is upstreamed; the dev/test
+# scaffolding (this workflow, the test file, hack/council-of-claudes/*) stays here.
+# See hack/council-of-claudes/README.md → "Upstream vs. calico-oss-test only".
+name: Council of Claudes tests
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/scripts/**'
+      - '.github/workflows/council-tests.yml'
+permissions:
+  contents: read
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      # Uses the runner's preinstalled Node (node:test is stable on Node 20+);
+      # no setup-node / dependencies needed.
+      - name: Run Council unit tests
+        run: node --test .github/workflows/scripts/*.test.js

--- a/.github/workflows/scripts/council_of_claudes.js
+++ b/.github/workflows/scripts/council_of_claudes.js
@@ -545,3 +545,10 @@ module.exports = async ({ github, context, core }) => {
   }
   core.info(`Done: ${summaries}/${active.length} summaries, ${inlineTotal} inline posted, ${dropped} duplicate(s) dropped on PR #${pull_number}`);
 };
+
+// Expose the pure helpers for unit tests (council_of_claudes.test.js). The default
+// export above stays the github-script entrypoint (`await fn({github,context,core})`);
+// these are attached as properties on it, so the entrypoint is unaffected.
+Object.assign(module.exports, {
+  annotateDiff, parseFindings, parseClusters, applyClusters, stripOuterFence, errDetail,
+});

--- a/.github/workflows/scripts/council_of_claudes.js
+++ b/.github/workflows/scripts/council_of_claudes.js
@@ -550,5 +550,5 @@ module.exports = async ({ github, context, core }) => {
 // export above stays the github-script entrypoint (`await fn({github,context,core})`);
 // these are attached as properties on it, so the entrypoint is unaffected.
 Object.assign(module.exports, {
-  annotateDiff, parseFindings, parseClusters, applyClusters, stripOuterFence, errDetail,
+  annotateDiff, parseFindings, parseClusters, applyClusters, stripOuterFence,
 });

--- a/.github/workflows/scripts/council_of_claudes.test.js
+++ b/.github/workflows/scripts/council_of_claudes.test.js
@@ -7,8 +7,8 @@ const test = require('node:test');
 const assert = require('node:assert');
 const path = require('node:path');
 
-const coc = require(path.join(__dirname, 'council_of_claudes.js'));
-const { annotateDiff, parseFindings, parseClusters, applyClusters, stripOuterFence } = coc;
+const council = require(path.join(__dirname, 'council_of_claudes.js'));
+const { annotateDiff, parseFindings, parseClusters, applyClusters, stripOuterFence } = council;
 
 // ----------------------------------------------------------------------------
 // Pure helpers
@@ -103,24 +103,37 @@ function makeFetch(orchOutcomes) {
   };
 }
 
+// Env keys the harness mutates — snapshot/restore so the suite stays hermetic.
+const ENV_KEYS = [
+  'CORRECTNESS_AGENT_URL', 'CORRECTNESS_AGENT_TOKEN', 'MAINTAINABILITY_AGENT_URL', 'MAINTAINABILITY_AGENT_TOKEN',
+  'SECURITY_AGENT_URL', 'SECURITY_AGENT_TOKEN', 'NELLJERRAM_AGENT_URL', 'NELLJERRAM_AGENT_TOKEN',
+  'CASEYDAVENPORT_AGENT_URL', 'CASEYDAVENPORT_AGENT_TOKEN', 'ORCHESTRATOR_AGENT_URL', 'ORCHESTRATOR_AGENT_TOKEN',
+  'GITHUB_WORKSPACE', 'GITHUB_RUN_ID', 'GITHUB_RUN_ATTEMPT',
+];
+
 async function runCouncil({ orchConfigured, orchOutcomes }) {
-  for (const k of ['CORRECTNESS', 'MAINTAINABILITY', 'SECURITY', 'NELLJERRAM', 'CASEYDAVENPORT', 'ORCHESTRATOR']) {
-    delete process.env[`${k}_AGENT_URL`]; delete process.env[`${k}_AGENT_TOKEN`];
+  const prevEnv = Object.fromEntries(ENV_KEYS.map(k => [k, process.env[k]]));
+  const prevFetch = global.fetch;
+  try {
+    for (const k of ENV_KEYS) delete process.env[k];
+    process.env.CORRECTNESS_AGENT_URL = CORR; process.env.CORRECTNESS_AGENT_TOKEN = 't';
+    process.env.NELLJERRAM_AGENT_URL = NELL; process.env.NELLJERRAM_AGENT_TOKEN = 't';
+    if (orchConfigured) { process.env.ORCHESTRATOR_AGENT_URL = ORCH; process.env.ORCHESTRATOR_AGENT_TOKEN = 't'; }
+    process.env.GITHUB_WORKSPACE = '/tmp/coc-nonexistent'; process.env.GITHUB_RUN_ID = '1'; process.env.GITHUB_RUN_ATTEMPT = '1';
+    global.fetch = makeFetch(orchOutcomes);
+    const posted = [];
+    const github = { paginate: async () => [], rest: { pulls: {
+      get: async () => ({ data: DIFF }), listReviews: () => {}, listReviewComments: () => {},
+      createReviewComment: async (a) => { posted.push(`${a.path}:${a.line}`); },
+      deleteReviewComment: async () => {}, createReview: async () => {}, updateReview: async () => {},
+    } } };
+    const context = { repo: { owner: 'o', repo: 'r' }, payload: { pull_request: { number: 1, title: 't', body: 'b', head: { sha: 's' } } } };
+    await council({ github, context, core: { info() {}, warning() {} } });
+    return posted.sort();
+  } finally {
+    for (const k of ENV_KEYS) { if (prevEnv[k] === undefined) delete process.env[k]; else process.env[k] = prevEnv[k]; }
+    global.fetch = prevFetch;
   }
-  process.env.CORRECTNESS_AGENT_URL = CORR; process.env.CORRECTNESS_AGENT_TOKEN = 't';
-  process.env.NELLJERRAM_AGENT_URL = NELL; process.env.NELLJERRAM_AGENT_TOKEN = 't';
-  if (orchConfigured) { process.env.ORCHESTRATOR_AGENT_URL = ORCH; process.env.ORCHESTRATOR_AGENT_TOKEN = 't'; }
-  process.env.GITHUB_WORKSPACE = '/tmp/coc-nonexistent'; process.env.GITHUB_RUN_ID = '1'; process.env.GITHUB_RUN_ATTEMPT = '1';
-  global.fetch = makeFetch(orchOutcomes);
-  const posted = [];
-  const github = { paginate: async () => [], rest: { pulls: {
-    get: async () => ({ data: DIFF }), listReviews: () => {}, listReviewComments: () => {},
-    createReviewComment: async (a) => { posted.push(`${a.path}:${a.line}`); },
-    deleteReviewComment: async () => {}, createReview: async () => {}, updateReview: async () => {},
-  } } };
-  const context = { repo: { owner: 'o', repo: 'r' }, payload: { pull_request: { number: 1, title: 't', body: 'b', head: { sha: 's' } } } };
-  await coc({ github, context, core: { info() {}, warning() {} } });
-  return posted.sort();
 }
 
 test('e2e: orchestrator dedups the cross-persona duplicate', async () => {
@@ -131,6 +144,11 @@ test('e2e: orchestrator dedups the cross-persona duplicate', async () => {
 test('e2e: input-required is terminal -> fresh-task retry recovers', async () => {
   const posted = await runCouncil({ orchConfigured: true, orchOutcomes: ['input-required', 'good'] });
   assert.deepEqual(posted, ['foo.go:10', 'foo.go:20', 'foo.go:30']);
+});
+
+test('e2e: orchestrator configured but all attempts fail -> graceful, post everything', async () => {
+  const posted = await runCouncil({ orchConfigured: true, orchOutcomes: ['failed', 'failed'] });
+  assert.deepEqual(posted, ['foo.go:10', 'foo.go:10', 'foo.go:20', 'foo.go:30']); // no dedup applied
 });
 
 test('e2e: orchestrator unconfigured -> graceful, post everything', async () => {

--- a/.github/workflows/scripts/council_of_claudes.test.js
+++ b/.github/workflows/scripts/council_of_claudes.test.js
@@ -1,0 +1,139 @@
+// Unit tests for council_of_claudes.js — run with: node --test
+// Zero dependencies (Node's built-in test runner + assert). calico-oss-test only:
+// this guards the Council logic during development here; it is NOT cherry-picked
+// upstream (see hack/council-of-claudes/README.md "Upstream vs. calico-oss-test only").
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+
+const coc = require(path.join(__dirname, 'council_of_claudes.js'));
+const { annotateDiff, parseFindings, parseClusters, applyClusters, stripOuterFence } = coc;
+
+// ----------------------------------------------------------------------------
+// Pure helpers
+// ----------------------------------------------------------------------------
+test('stripOuterFence: strips a whole-response markdown fence, keeps inner fences', () => {
+  assert.equal(stripOuterFence('```markdown\nhello\n```'), 'hello');
+  assert.equal(stripOuterFence('plain text'), 'plain text');
+  const inner = 'before\n```go\ncode\n```\nafter';
+  assert.equal(stripOuterFence(inner), inner); // not wrapped as a single outer fence
+});
+
+test('annotateDiff: numbers new-side lines, builds anchor set, ignores deletes/metadata', () => {
+  const diff = [
+    'diff --git a/foo.go b/foo.go', '--- a/foo.go', '+++ b/foo.go',
+    '@@ -10,2 +10,2 @@', ' ctx', '-gone', '+added', '',
+  ].join('\n');
+  const { annotated, anchors } = annotateDiff(diff);
+  const f = anchors.get('foo.go');
+  assert.ok(f.has(10) && f.has(11), 'context + added lines anchorable');
+  assert.equal(f.size, 2, 'exactly the two new-side lines'); // deleted line not anchored
+  assert.ok(annotated.includes('[L10]') && annotated.includes('[L11]'));
+  assert.ok(!annotated.includes('[L12]'), 'trailing blank split element not annotated');
+});
+
+test('parseFindings: splits summary from coc-finding anchored findings', () => {
+  const text = 'Verdict line.\nmore summary\n\n'
+    + '<!-- coc-finding file="a.go" line="5" -->\nFix A.\n\n'
+    + '<!-- coc-finding file="b.go" line="9" -->\nFix B.';
+  const { summary, findings } = parseFindings(text);
+  assert.match(summary, /Verdict line/);
+  assert.equal(findings.length, 2);
+  assert.deepEqual({ f: findings[0].file, l: findings[0].line }, { f: 'a.go', l: 5 });
+  assert.match(findings[0].body, /Fix A\./);
+  assert.equal(findings[1].line, 9);
+});
+
+test('parseFindings: no markers -> all summary, no findings', () => {
+  const { summary, findings } = parseFindings('just a verdict, nothing anchored');
+  assert.equal(findings.length, 0);
+  assert.equal(summary, 'just a verdict, nothing anchored');
+});
+
+test('parseClusters: tolerates fenced / single-line-fenced / prose-wrapped JSON', () => {
+  const obj = '{"clusters":[{"survivor":"a","duplicates":["b"],"reason":"x"}]}';
+  assert.equal(parseClusters(obj).clusters.length, 1);
+  assert.equal(parseClusters('```json\n' + obj + '\n```').clusters.length, 1);
+  assert.equal(parseClusters('```json ' + obj + ' ```').clusters.length, 1); // single-line fence
+  assert.equal(parseClusters('Here you go:\n' + obj + '\nThanks!').clusters.length, 1);
+  assert.equal(parseClusters('sorry, no json'), null);
+  assert.equal(parseClusters(''), null);
+});
+
+test('applyClusters: drops duplicates, keep-wins, ignores unknown ids, omission=keep', () => {
+  const core = { info() {}, warning() {} };
+  const allInline = ['a', 'b', 'c', 'd'].map(id => ({ id }));
+  // b is a duplicate of survivor a; d is unmentioned (kept); ghost is unknown.
+  const parsed = { clusters: [
+    { survivor: 'a', duplicates: ['b', 'ghost'], reason: 'r' },
+    { survivor: 'd', duplicates: ['a'] }, // a also survives elsewhere -> keep-wins
+  ] };
+  const drop = applyClusters({ core, allInline, parsed });
+  assert.ok(drop.has('b'), 'b dropped');
+  assert.ok(!drop.has('a'), 'a kept (keep-wins despite being listed as a duplicate)');
+  assert.ok(!drop.has('ghost'), 'unknown id ignored');
+  assert.ok(!drop.has('c') && !drop.has('d'), 'unmentioned / survivors kept');
+  assert.equal(drop.size, 1);
+});
+
+// ----------------------------------------------------------------------------
+// End-to-end via the github-script entrypoint (stubbed fetch + github)
+// ----------------------------------------------------------------------------
+const DIFF = ['diff --git a/foo.go b/foo.go', '--- a/foo.go', '+++ b/foo.go',
+  '@@ -10,0 +10,1 @@', '+ten', '@@ -20,0 +20,1 @@', '+twenty', '@@ -30,0 +30,1 @@', '+thirty'].join('\n');
+const CORR = 'http://corr', NELL = 'http://nell', ORCH = 'http://orch';
+const corrReview = 'V.\n\n<!-- coc-finding file="foo.go" line="10" -->\nuse EqualFold.\n\n<!-- coc-finding file="foo.go" line="20" -->\nNil deref.';
+const nellReview = 'F.\n\n<!-- coc-finding file="foo.go" line="10" -->\nEqualFold? case-sensitive.\n\n<!-- coc-finding file="foo.go" line="30" -->\nNaming.';
+const CLUSTERS = '{"clusters":[{"survivor":"correctness-0","duplicates":["nelljerram-0"],"reason":"dup"}]}';
+
+// orchOutcomes[attempt-1]: 'good' | 'input-required' | 'failed'  (orchestrator only)
+function makeFetch(orchOutcomes) {
+  return async (url, opts) => {
+    const b = JSON.parse(opts.body);
+    if (b.method === 'message/send') return { ok: true, json: async () => ({ result: { id: b.id, status: { state: 'submitted' } } }) };
+    if (url === CORR || url === NELL) {
+      const text = url === CORR ? corrReview : nellReview;
+      return { ok: true, json: async () => ({ result: { status: { state: 'completed' }, artifacts: [{ parts: [{ text }] }] } }) };
+    }
+    const attempt = parseInt(b.params.id.split('-').pop(), 10);
+    const o = (orchOutcomes || [])[attempt - 1] || 'failed';
+    if (o === 'good') return { ok: true, json: async () => ({ result: { status: { state: 'completed' }, artifacts: [{ parts: [{ text: CLUSTERS }] }] } }) };
+    return { ok: true, json: async () => ({ result: { status: { state: o } } }) };
+  };
+}
+
+async function runCouncil({ orchConfigured, orchOutcomes }) {
+  for (const k of ['CORRECTNESS', 'MAINTAINABILITY', 'SECURITY', 'NELLJERRAM', 'CASEYDAVENPORT', 'ORCHESTRATOR']) {
+    delete process.env[`${k}_AGENT_URL`]; delete process.env[`${k}_AGENT_TOKEN`];
+  }
+  process.env.CORRECTNESS_AGENT_URL = CORR; process.env.CORRECTNESS_AGENT_TOKEN = 't';
+  process.env.NELLJERRAM_AGENT_URL = NELL; process.env.NELLJERRAM_AGENT_TOKEN = 't';
+  if (orchConfigured) { process.env.ORCHESTRATOR_AGENT_URL = ORCH; process.env.ORCHESTRATOR_AGENT_TOKEN = 't'; }
+  process.env.GITHUB_WORKSPACE = '/tmp/coc-nonexistent'; process.env.GITHUB_RUN_ID = '1'; process.env.GITHUB_RUN_ATTEMPT = '1';
+  global.fetch = makeFetch(orchOutcomes);
+  const posted = [];
+  const github = { paginate: async () => [], rest: { pulls: {
+    get: async () => ({ data: DIFF }), listReviews: () => {}, listReviewComments: () => {},
+    createReviewComment: async (a) => { posted.push(`${a.path}:${a.line}`); },
+    deleteReviewComment: async () => {}, createReview: async () => {}, updateReview: async () => {},
+  } } };
+  const context = { repo: { owner: 'o', repo: 'r' }, payload: { pull_request: { number: 1, title: 't', body: 'b', head: { sha: 's' } } } };
+  await coc({ github, context, core: { info() {}, warning() {} } });
+  return posted.sort();
+}
+
+test('e2e: orchestrator dedups the cross-persona duplicate', async () => {
+  const posted = await runCouncil({ orchConfigured: true, orchOutcomes: ['good'] });
+  assert.deepEqual(posted, ['foo.go:10', 'foo.go:20', 'foo.go:30']); // nell's line-10 dup dropped
+});
+
+test('e2e: input-required is terminal -> fresh-task retry recovers', async () => {
+  const posted = await runCouncil({ orchConfigured: true, orchOutcomes: ['input-required', 'good'] });
+  assert.deepEqual(posted, ['foo.go:10', 'foo.go:20', 'foo.go:30']);
+});
+
+test('e2e: orchestrator unconfigured -> graceful, post everything', async () => {
+  const posted = await runCouncil({ orchConfigured: false });
+  assert.deepEqual(posted, ['foo.go:10', 'foo.go:10', 'foo.go:20', 'foo.go:30']); // both line-10 comments kept
+});

--- a/hack/council-of-claudes/README.md
+++ b/hack/council-of-claudes/README.md
@@ -59,3 +59,43 @@ Writes `comparison-<N>.md`: a side-by-side of the **original human** review comm
 - The **reproduction modes** (as-first-reviewed vs. full-diff) are described under
   `gen-benchmark-pr.sh` above.
 - These reproduce PRs against this **fork** (`calico-oss-test`), never upstream.
+
+## Tests
+Unit tests for the Council review logic live next to the script:
+`.github/workflows/scripts/council_of_claudes.test.js`. Run them with:
+```sh
+node --test .github/workflows/scripts/*.test.js
+```
+Zero dependencies (Node's built-in `node:test` runner, Node 20+). CI runs them on PRs that touch
+`.github/workflows/scripts/**` via `.github/workflows/council-tests.yml`.
+
+## Upstream vs. calico-oss-test only
+The Council has two kinds of artifact. Be deliberate about the boundary when cherry-picking.
+
+**Product → cherry-picked upstream to `projectcalico/calico`** (it runs live and reviews real PRs):
+- `.github/workflows/council_of_claudes.yml` (the review workflow)
+- `.github/workflows/scripts/council_of_claudes.js` (orchestration + dedup logic)
+- `.github/workflows/scripts/personas/*.md`, `.github/workflows/scripts/orchestrator.md` (agent prompts)
+
+**Dev / test / benchmark scaffolding → stays in `calico-oss-test` only** (never cherry-picked):
+- `hack/council-of-claudes/**` (this dir: `gen-benchmark-pr.sh`, `eval-benchmark-pr.py`, design docs, README)
+- `.github/workflows/scripts/council_of_claudes.test.js` (unit tests)
+- `.github/workflows/council-tests.yml` (test CI)
+
+Keep these in separate commits from product changes so a product cherry-pick naturally leaves the
+scaffolding behind.
+
+### Sync practices (keeping the round-trip conflict-free)
+Council changes start here → are cherry-picked upstream → then flow back when `calico-oss-test` pulls
+from upstream. To keep that low-conflict:
+- **Sync from upstream frequently** — small, frequent merges converge cleanly; large divergence is
+  where conflicts pile up.
+- **Use *merge*, not *rebase*, for the upstream sync** — rebasing would replay Council commits that
+  upstream already has (via cherry-pick) → empty/conflicting picks; a merge lets identical content
+  converge with no conflict.
+- **Keep cherry-picks content-identical** (don't tweak the code during the upstream PR) so the
+  returning copy converges with the local one.
+- **Don't re-edit an already-upstreamed product file independently here** — once it's upstream, let
+  it come from upstream; make the next change a fresh branch → upstream cycle.
+
+The scaffolding above has no upstream counterpart, so it never conflicts with an upstream sync.


### PR DESCRIPTION
## What (Tier 1 + Tier 3 from the test-harness plan)
A lightweight, zero-dependency unit-test harness for the Council review logic, plus CI to run it — scoped to `calico-oss-test` only.

## Changes (two commits, deliberately split for a clean cherry-pick boundary)
1. **`council_of_claudes.js` — export seam** (product file): attaches the pure helpers as properties on the existing entrypoint. The github-script entrypoint is unchanged; harmless if carried upstream with the product file.
2. **Scaffolding (stays in calico-oss-test, never cherry-picked):**
   - `council_of_claudes.test.js` — **9 tests**, zero deps (Node's `node:test`): pure helpers (`annotateDiff`, `parseFindings`, `parseClusters`, `applyClusters`, `stripOuterFence`) + end-to-end (`dedup applied`, `input-required → retry recovers`, `unconfigured → graceful post-all`). Most of our throwaway mocks are now permanent.
   - `council-tests.yml` — runs `node --test` on PRs touching `.github/workflows/scripts/**`. Uses the runner's Node (no setup-node/deps).
   - `README` — how to run the tests, the **"Upstream vs. calico-oss-test only"** boundary (product cherry-picked; scaffolding stays here), and **upstream-sync practices** to keep the cherry-pick round-trip conflict-free.

## Run locally
```sh
node --test .github/workflows/scripts/*.test.js   # 9 tests, ~0.1s
```

## Why calico-oss-test only
Development happens in this fork; upstream is the deployment target (receives cherry-picked, already-tested product). The test CI guards the dev process here and keeps the upstream footprint minimal. Boundary + rationale documented in the README.

Deferred (separate PR if wanted): bash tests for `gen-benchmark-pr.sh` (Tier 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)