### PR TITLE
[mergecat-test] pending pick + backport demo

### DIFF
--- a/mergecat-test/demo.md
+++ b/mergecat-test/demo.md
@@ -1,0 +1,1 @@
+merge-cat test fixture: pending pick + backport demo.


### PR DESCRIPTION
Test fixture for merge-cat: should show as a pending cherry-pick to calico-enterprise-test master and a pending backport to release-v3.31/release-v3.32.